### PR TITLE
fix(frontend): keep media placeholders past the first message

### DIFF
--- a/src/targets/qwen3_6/impl/frontend/jinja_chat_render.cpp
+++ b/src/targets/qwen3_6/impl/frontend/jinja_chat_render.cpp
@@ -8,6 +8,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -125,23 +126,27 @@ json build_context(const std::vector<ChatMessage>& messages, const ChatRenderOpt
     return context;
 }
 
-// A run of consecutive trace iterations belonging to one loop statement.
+// The trace iterations of one execution of a for statement, in record order. A loop
+// nested inside an iteration — the content macro's loop over the parts of one message —
+// records its own iterations before the enclosing iteration closes, so the enclosing
+// loop's records are not consecutive and are grouped by invocation instead.
 struct LoopRun {
     std::string loop;
-    std::size_t begin = 0;
-    std::size_t count = 0;
+    std::vector<std::size_t> iterations;
 };
 
 std::vector<LoopRun> loop_runs(const jinja::RenderTrace& trace) {
     std::vector<LoopRun> runs;
+    std::unordered_map<std::size_t, std::size_t> run_of_invocation;
     for (std::size_t index = 0; index < trace.loop_iterations.size(); ++index) {
-        const std::string& loop = trace.loop_iterations[index].loop;
-        if (!runs.empty() && runs.back().loop == loop &&
-            runs.back().begin + runs.back().count == index) {
-            ++runs.back().count;
+        const jinja::RenderTrace::LoopIteration& iteration = trace.loop_iterations[index];
+        const auto [entry, inserted] = run_of_invocation.try_emplace(iteration.invocation,
+                                                                     runs.size());
+        if (inserted) {
+            runs.push_back(LoopRun{iteration.loop, {index}});
             continue;
         }
-        runs.push_back(LoopRun{loop, index, 1U});
+        runs[entry->second].iterations.push_back(index);
     }
     return runs;
 }
@@ -150,36 +155,36 @@ std::vector<LoopRun> loop_runs(const jinja::RenderTrace& trace) {
 // role order rather than by variable spelling, so a renamed loop variable does not break
 // the mapping.
 struct MessageLoop {
-    std::size_t begin = 0;
-    std::size_t count = 0;
-    std::size_t offset = 0; // input messages folded into the preamble
+    std::vector<std::size_t> iterations; // indices into trace.loop_iterations
+    std::size_t offset = 0;              // input messages folded into the preamble
 };
 
 std::optional<MessageLoop> select_message_loop(const jinja::RenderTrace& trace,
                                                const std::vector<ChatMessage>& messages) {
     for (const LoopRun& run : loop_runs(trace)) {
+        const std::size_t count = run.iterations.size();
         std::size_t emitted = 0;
         bool contiguous = true;
-        for (std::size_t index = 0; index < run.count; ++index) {
-            const auto& iteration = trace.loop_iterations[run.begin + index];
+        for (std::size_t index = 0; index < count; ++index) {
+            const auto& iteration = trace.loop_iterations[run.iterations[index]];
             emitted += iteration.end - iteration.begin;
             if (index != 0 &&
-                trace.loop_iterations[run.begin + index - 1U].end != iteration.begin) {
+                trace.loop_iterations[run.iterations[index - 1U]].end != iteration.begin) {
                 contiguous = false;
             }
         }
         if (emitted == 0 || !contiguous) { continue; }
         for (const std::size_t offset : {std::size_t{0}, std::size_t{1}}) {
-            if (run.count + offset != messages.size()) { continue; }
+            if (count + offset != messages.size()) { continue; }
             bool matches = true;
-            for (std::size_t index = 0; index < run.count; ++index) {
-                if (trace.loop_iterations[run.begin + index].item_role !=
+            for (std::size_t index = 0; index < count; ++index) {
+                if (trace.loop_iterations[run.iterations[index]].item_role !=
                     role_name(messages[index + offset].role)) {
                     matches = false;
                     break;
                 }
             }
-            if (matches) { return MessageLoop{run.begin, run.count, offset}; }
+            if (matches) { return MessageLoop{run.iterations, offset}; }
         }
     }
     return std::nullopt;
@@ -190,11 +195,16 @@ struct Leaf {
     std::size_t end = 0;
 };
 
-// Finds the printed leaf named `expr` inside [begin, end) and returns its byte span.
+// Finds the printed leaf named `expr` inside [begin, end) and returns its byte span. A
+// print of the bare value carries no operand parts, so its own expression is the leaf.
 std::optional<Leaf> find_leaf(const jinja::RenderTrace& trace, std::size_t begin, std::size_t end,
                               std::string_view expr) {
     for (const auto& print : trace.prints) {
         if (print.begin < begin || print.end > end) { continue; }
+        if (print.parts.empty()) {
+            if (print.expr == expr) { return Leaf{print.begin, print.end}; }
+            continue;
+        }
         std::size_t offset = print.begin;
         for (const auto& part : print.parts) {
             if (part.expr == expr) { return Leaf{offset, offset + part.length}; }
@@ -377,16 +387,19 @@ RenderedChat JinjaChatTemplate::render(const std::vector<ChatMessage>& messages,
     if (!loop) { return rendered; }
 
     const auto& iterations = trace.loop_iterations;
-    const std::size_t loop_begin = iterations[loop->begin].begin;
-    const std::size_t loop_end   = iterations[loop->begin + loop->count - 1U].end;
+    const std::size_t loop_count = loop->iterations.size();
+    const auto& loop_first       = iterations[loop->iterations.front()];
+    const std::size_t loop_begin = loop_first.begin;
+    const std::size_t loop_end   = iterations[loop->iterations.back()].end;
     // A leading instruction message is folded into the preamble by the template, and the
     // loop then has no emitted block for it. Such a message has no independent frontier, so
     // only the frontier that follows it is recorded.
-    const bool first_iteration_emits = iterations[loop->begin].end > iterations[loop->begin].begin;
+    const bool first_iteration_emits = loop_first.end > loop_first.begin;
     rendered.message_boundaries[loop->offset] =
         first_iteration_emits ? std::optional<std::size_t>(loop_begin) : std::nullopt;
-    for (std::size_t index = first_iteration_emits ? 0U : 1U; index < loop->count; ++index) {
-        rendered.message_boundaries[loop->offset + index + 1U] = iterations[loop->begin + index].end;
+    for (std::size_t index = first_iteration_emits ? 0U : 1U; index < loop_count; ++index) {
+        rendered.message_boundaries[loop->offset + index + 1U] =
+            iterations[loop->iterations[index]].end;
     }
     if (!first_iteration_emits) {
         // The folded message's frontier is the preamble end, which is where the loop starts.
@@ -414,8 +427,8 @@ RenderedChat JinjaChatTemplate::render(const std::vector<ChatMessage>& messages,
 
     std::size_t media_index = 0;
     std::vector<std::vector<std::size_t>> part_offsets(messages.size());
-    for (std::size_t index = 0; index < loop->count; ++index) {
-        const auto& iteration = iterations[loop->begin + index];
+    for (std::size_t index = 0; index < loop_count; ++index) {
+        const auto& iteration = iterations[loop->iterations[index]];
         const std::size_t message_index = loop->offset + index;
         const ChatMessage& message = messages[message_index];
         if (const auto leaf = find_leaf(trace, iteration.begin, iteration.end, "reasoning_content")) {
@@ -461,10 +474,10 @@ RenderedChat JinjaChatTemplate::render(const std::vector<ChatMessage>& messages,
     // from the trace as well.
     std::vector<std::size_t> tool_boundaries;
     for (const LoopRun& run : loop_runs(trace)) {
-        if (run.loop != "tools" || run.count == 0) { continue; }
-        if (iterations[run.begin].begin < loop_end) { continue; }
-        for (std::size_t index = 0; index < run.count; ++index) {
-            tool_boundaries.push_back(iterations[run.begin + index].end);
+        if (run.loop != "tools" || run.iterations.empty()) { continue; }
+        if (iterations[run.iterations.front()].begin < loop_end) { continue; }
+        for (const std::size_t index : run.iterations) {
+            tool_boundaries.push_back(iterations[index].end);
         }
     }
 
@@ -512,9 +525,9 @@ RenderedChat JinjaChatTemplate::render(const std::vector<ChatMessage>& messages,
         last_query = messages.size() > 50U ? static_cast<long>(messages.size()) - 1 : 0;
     }
 
-    if (options.continuation == PromptContinuationMode::ContinueFinalAssistant && loop->count != 0) {
+    if (options.continuation == PromptContinuationMode::ContinueFinalAssistant && loop_count != 0) {
         // The final assistant turn is replayed and may be rewritten as the response continues.
-        const auto& iteration = iterations[loop->begin + loop->count - 1U];
+        const auto& iteration = iterations[loop->iterations.back()];
         rendered.rewrite_checkpoint =
             RewriteCheckpointByteSpec{RewriteCheckpointKind::ResponseReplay, iteration.begin};
     } else if (options.add_generation_prompt) {
@@ -535,11 +548,11 @@ RenderedChat JinjaChatTemplate::render(const std::vector<ChatMessage>& messages,
                 *suffix_begin};
         }
     } else if (!preserve_thinking) {
-        for (std::size_t index = 0; index < loop->count; ++index) {
+        for (std::size_t index = 0; index < loop_count; ++index) {
             const std::size_t message_index = loop->offset + index;
             if (messages[message_index].role != ChatRole::Assistant) { continue; }
             if (static_cast<long>(message_index) <= last_query) { continue; }
-            const auto& iteration = iterations[loop->begin + index];
+            const auto& iteration = iterations[loop->iterations[index]];
             rendered.rewrite_checkpoint =
                 RewriteCheckpointByteSpec{RewriteCheckpointKind::TurnClosure, iteration.begin};
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -134,6 +134,15 @@ ninfer_add_test(ninfer_qwen3_6_jinja_frontend_render_test
 target_include_directories(ninfer_qwen3_6_jinja_frontend_render_test PRIVATE
   ${PROJECT_SOURCE_DIR}/src/targets/qwen3_6/export
   ${PROJECT_SOURCE_DIR}/src/targets/qwen3_6/impl)
+# Holds the media placeholder mapping for an image in any message position, across the
+# registered templates including the one the deployed qwen3.8 artifact embeds.
+ninfer_add_test(ninfer_qwen3_6_jinja_vision_mapping_test
+  SOURCES targets/qwen3_6/test_jinja_vision_mapping.cpp
+  NEEDS_SOURCE_DIR
+  LIBRARIES ninfer_engine ninfer_core)
+target_include_directories(ninfer_qwen3_6_jinja_vision_mapping_test PRIVATE
+  ${PROJECT_SOURCE_DIR}/src/targets/qwen3_6/export
+  ${PROJECT_SOURCE_DIR}/src/targets/qwen3_6/impl)
 ninfer_add_test(ninfer_qwen3_6_runtime_mechanisms_test
   SOURCES targets/qwen3_6/test_runtime_mechanisms.cpp
   LIBRARIES ninfer_engine ninfer_core)

--- a/tests/fixtures/frontend/qwen38_reasoning_effort_deployed_chat_template.jinja
+++ b/tests/fixtures/frontend/qwen38_reasoning_effort_deployed_chat_template.jinja
@@ -1,0 +1,170 @@
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- set reasoning_instructions = '' %}
+{%- if enable_thinking is undefined or enable_thinking is true %}
+    {%- set resolved_reasoning_effort = reasoning_effort|default('xhigh') %}
+    {%- if resolved_reasoning_effort not in ('xhigh', 'medium', 'low') %}
+        {{- raise_exception('Unexpected reasoning effort ' ~ reasoning_effort ~ '. Supported types are xhigh (default), medium, and low.') }}
+    {%- endif %}
+    {%- if resolved_reasoning_effort == 'xhigh' %}
+        {%- set reasoning_instructions = 'Reasoning effort is set to xhigh. Please think carefully through the task, validate key assumptions, consider plausible alternatives, and prioritize correctness, consistency, and clarity in the final answer.' %}
+    {%- elif resolved_reasoning_effort == 'low' %}
+        {%- set reasoning_instructions = 'Reasoning effort is set to low. Keep your thinking brief and focused, moving directly to the conclusion without unnecessary elaboration.' %}
+    {%- endif %}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {%- if reasoning_instructions %}
+        {{- reasoning_instructions + '\n\n' }}
+    {%- endif %}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '\n\n' + content }}
+        {%- endif %}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '<|im_start|>system\n' + (reasoning_instructions + '\n\n' if reasoning_instructions else '')  + content + '<|im_end|>\n' }}
+        {%- elif reasoning_instructions %}
+            {{- '<|im_start|>system\n' + reasoning_instructions + '<|im_end|>\n' }}
+        {%- endif %}
+    {%- elif reasoning_instructions %}
+        {{- '<|im_start|>system\n' + reasoning_instructions + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if ns.multi_step_tool %}
+    {{- raise_exception('No user query found in messages.') }}
+{%- endif %}
+{%- for message in messages %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if message.role == "system" %}
+        {%- if not loop.first %}
+            {{- raise_exception('System message must be at the beginning.') }}
+        {%- endif %}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {%- if preserve_thinking is undefined or preserve_thinking is true or loop.index0 > ns.last_query_index %}
+            {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is defined and tool_call.arguments != '' %}
+                    {%- for args_name, args_value in tool_call.arguments|items %}
+                        {{- '<parameter=' + args_name + '>\n' }}
+                        {%- set args_value = args_value | string if args_value is string else args_value | tojson | safe %}
+                        {{- args_value }}
+                        {{- '\n</parameter>\n' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- raise_exception('Unexpected message role.') }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}

--- a/tests/targets/qwen3_6/test_jinja_vision_mapping.cpp
+++ b/tests/targets/qwen3_6/test_jinja_vision_mapping.cpp
@@ -1,0 +1,175 @@
+// Validates that the structured render description keeps every media placeholder a
+// registered template emits, whatever position the image-bearing message holds.
+//
+// The frontend expands one placeholder per input image; a lost placeholder rejects the
+// request with "chat media count does not match rendered placeholders", so a mapping
+// that only holds for an image in the first message breaks vision for every later turn
+// (an image after a tool result, or after any earlier exchange).
+//
+// The digest-registered template the deployed qwen3.8 artifact embeds is one of the
+// files exercised here: the render oracle suite runs a stand-in for it, and the
+// mapping depends on template shape.
+
+#include "targets/qwen3_6/impl/frontend/chat_template.h"
+#include "targets/qwen3_6/impl/frontend/jinja_chat_render.h"
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace fi = ninfer::targets::qwen3_6::frontend_internal;
+
+namespace {
+
+std::string read_file(const std::string& path) {
+    std::ifstream file(path, std::ios::binary);
+    std::ostringstream buffer;
+    buffer << file.rdbuf();
+    return buffer.str();
+}
+
+int fail(const std::string& message) {
+    std::cerr << "FAIL: " << message << '\n';
+    return 1;
+}
+
+fi::ChatMessage text_message(ninfer::ChatRole role, const std::string& text) {
+    fi::ChatMessage message;
+    message.role = role;
+    message.parts.push_back(fi::ChatPart::text_part(text));
+    return message;
+}
+
+fi::ChatMessage image_message(ninfer::ChatRole role, const std::string& text) {
+    fi::ChatMessage message = text_message(role, text);
+    fi::ChatPart part;
+    part.kind = fi::ChatPartKind::Image;
+    message.parts.push_back(std::move(part));
+    return message;
+}
+
+fi::ChatMessage tool_call_message(const std::string& name) {
+    fi::ChatMessage message = text_message(ninfer::ChatRole::Assistant, "");
+    fi::ToolCall call;
+    call.id             = "call-1";
+    call.name           = name;
+    call.arguments_json = R"({"path":"shot.png"})";
+    message.tool_calls.push_back(std::move(call));
+    return message;
+}
+
+std::size_t image_parts(const std::vector<fi::ChatMessage>& messages) {
+    std::size_t count = 0;
+    for (const fi::ChatMessage& message : messages) {
+        for (const fi::ChatPart& part : message.parts) {
+            if (part.kind == fi::ChatPartKind::Image) { ++count; }
+        }
+    }
+    return count;
+}
+
+// One placeholder per image, in input order, each covering the image pad token it stands for.
+int check_media_mapping(const std::string& label, const std::vector<fi::ChatMessage>& messages,
+                        const fi::RenderedChat& rendered) {
+    const std::size_t images = image_parts(messages);
+    if (rendered.media_placeholders.size() != images) {
+        return fail(label + ": " + std::to_string(images) + " images mapped onto " +
+                    std::to_string(rendered.media_placeholders.size()) + " placeholders");
+    }
+    int failures = 0;
+    for (std::size_t index = 0; index < rendered.media_placeholders.size(); ++index) {
+        const fi::MediaPlaceholderByteSpec& placeholder = rendered.media_placeholders[index];
+        if (placeholder.item_index != index) {
+            failures += fail(label + ": placeholder " + std::to_string(index) +
+                             " is out of input order");
+            break;
+        }
+        if (placeholder.bytes.end > rendered.text.size() ||
+            rendered.text.substr(placeholder.bytes.begin,
+                                 placeholder.bytes.end - placeholder.bytes.begin) !=
+                "<|image_pad|>") {
+            failures += fail(label + ": placeholder " + std::to_string(index) +
+                             " does not cover the image pad token");
+            break;
+        }
+    }
+    return failures;
+}
+
+struct Shape {
+    const char* name;
+    std::vector<fi::ChatMessage> messages;
+};
+
+} // namespace
+
+int main() {
+    const std::string fixture_dir = NINFER_SOURCE_DIR "/tests/fixtures/frontend/";
+    const char* templates[] = {
+        "froggeric_v225_chat_template.jinja",
+        // The template the deployed qwen3.8 artifact embeds.
+        "qwen38_reasoning_effort_deployed_chat_template.jinja",
+    };
+
+    std::vector<Shape> shapes;
+    shapes.push_back({"first-message-image", {image_message(ninfer::ChatRole::User, "look: ")}});
+    shapes.push_back({"image-then-turn",
+                      {image_message(ninfer::ChatRole::User, "look: "),
+                       text_message(ninfer::ChatRole::Assistant, "a red square"),
+                       text_message(ninfer::ChatRole::User, "and now?")}});
+    // What a client sends on the turn after any earlier exchange.
+    shapes.push_back({"image-after-turn",
+                      {text_message(ninfer::ChatRole::User, "hi"),
+                       text_message(ninfer::ChatRole::Assistant, "hello"),
+                       image_message(ninfer::ChatRole::User, "look: ")}});
+    // What a client sends when a tool returns an image: the tool result carries it, or the
+    // user turn that follows the result does.
+    shapes.push_back({"image-in-tool-result",
+                      {text_message(ninfer::ChatRole::User, "read shot.png"),
+                       tool_call_message("read"),
+                       image_message(ninfer::ChatRole::Tool, "shot.png: "),
+                       text_message(ninfer::ChatRole::User, "what is it?")}});
+    shapes.push_back({"image-after-tool-result",
+                      {text_message(ninfer::ChatRole::User, "read shot.png"),
+                       tool_call_message("read"),
+                       text_message(ninfer::ChatRole::Tool, "shot.png: 64x64 png"),
+                       image_message(ninfer::ChatRole::User, "look: ")}});
+    shapes.push_back({"images-in-two-turns",
+                      {image_message(ninfer::ChatRole::User, "first: "),
+                       text_message(ninfer::ChatRole::Assistant, "seen"),
+                       image_message(ninfer::ChatRole::User, "second: ")}});
+
+    int failures = 0;
+    int checked  = 0;
+    for (const char* file : templates) {
+        const fi::JinjaChatTemplate compiled =
+            fi::JinjaChatTemplate::compile(read_file(fixture_dir + file));
+        for (const Shape& shape : shapes) {
+            const std::string label = std::string(file) + "/" + shape.name;
+            fi::ChatRenderOptions options;
+            options.add_generation_prompt = true;
+            fi::RenderedChat rendered;
+            try {
+                rendered = compiled.render(shape.messages, options);
+            } catch (const std::exception& error) {
+                failures += fail(label + " threw: " + error.what());
+                continue;
+            }
+            failures += check_media_mapping(label, shape.messages, rendered);
+            // A lost message loop drops every per-message frontier along with the
+            // placeholders, so the boundaries are part of the same contract.
+            for (std::size_t index = 1; index <= shape.messages.size(); ++index) {
+                if (!rendered.message_boundaries[index]) {
+                    failures += fail(label + ": message boundary " + std::to_string(index) +
+                                     " was not mapped");
+                    break;
+                }
+            }
+            ++checked;
+        }
+    }
+    if (failures == 0) { std::cout << "ok (" << checked << " renders)\n"; }
+    return failures == 0 ? 0 : 1;
+}

--- a/third_party/jinja/jinja.hpp
+++ b/third_party/jinja/jinja.hpp
@@ -63,6 +63,10 @@ struct RenderTrace {
     struct LoopIteration {
         std::string loop;              // iterable expression, e.g. "_msgs"
         std::vector<std::string> vars; // loop variable names
+        // Identifies the one execution of the for statement this iteration belongs to.
+        // A nested loop inside an iteration records its own iterations first, so record
+        // order alone does not group a loop's iterations together.
+        std::size_t invocation = 0;
         std::size_t index = 0;         // position within the iterated sequence
         std::size_t begin = 0;         // output offset at iteration start
         std::size_t end = 0;           // output offset at iteration end
@@ -85,11 +89,15 @@ struct RenderTrace {
     std::vector<PrintSpan> prints;
     // One frame per expression currently being printed by a PrintNode.
     std::vector<std::vector<ValuePart>> value_stack;
+    // Source of loop invocation ids; never reused within one render.
+    std::size_t loop_invocations = 0;
     void clear() {
         loop_iterations.clear();
         prints.clear();
         value_stack.clear();
+        loop_invocations = 0;
     }
+    [[nodiscard]] std::size_t begin_loop() { return ++loop_invocations; }
     void begin_value() { value_stack.emplace_back(); }
     [[nodiscard]] std::vector<ValuePart> end_value() {
         if (value_stack.empty()) { return {}; }
@@ -1547,9 +1555,15 @@ inline json CallExpr::evaluate(Context& context) {
             }
             context.push_scope(scope);
             std::string out;
+            // A macro body renders into its own buffer, so its print and loop offsets
+            // belong to that buffer rather than to the output being traced. Recording
+            // them would publish spans that address the wrong text.
+            RenderTrace* const trace = context.trace();
+            context.set_trace(nullptr);
             for (const auto& node : macro->body) {
                 node->render(context, out);
             }
+            context.set_trace(trace);
             context.pop_scope();
             return out;
     }
@@ -1702,6 +1716,7 @@ struct ForStmt : Node {
         len = filtered_items.size();
         index = 0;
         JINJA_LOG("Render For: Iterating " << len << " items.");
+        const std::size_t invocation = context.trace() ? context.trace()->begin_loop() : 0;
 
         for (const auto& item : filtered_items) {
              json loop_scope;
@@ -1736,6 +1751,7 @@ struct ForStmt : Node {
                  RenderTrace::LoopIteration record;
                  record.loop            = iterable->dump();
                  record.vars            = loop_vars;
+                 record.invocation      = invocation;
                  record.index           = index;
                  record.begin           = iteration_begin;
                  record.end             = out.size();


### PR DESCRIPTION
An image in any message but the first is rejected with `chat media count does not match rendered placeholders`. Reproduced on `master` at 555K/nvfp4/vision with the Ostfralla qwen3.8 artifact; an OpenAI client hits it on every turn after the first, and on every tool result that carries an image.

## Cause

`select_message_loop` groups trace iterations by adjacency. A loop nested inside a message iteration — `render_content`'s loop over one message's parts, or the `tool_calls` loop — closes before the iteration containing it, so the message loop's records are not consecutive and the run splits. No run then matches the message count, `render` returns early, and the whole structured description is dropped: every media placeholder and every message frontier with it.

Two mapping faults sat behind that:

- a macro body renders into its own buffer, so its print and loop offsets address that buffer, not the traced output;
- a print of a bare value carries no operand parts, so the print's own expression is the leaf — the form the tool branch uses for message content.

## Fix

- `jinja.hpp`: each `for` execution takes an invocation id; macro bodies render untraced.
- `jinja_chat_render.cpp`: runs group by invocation, not adjacency; bare-value prints resolve as leaves.

## Test

`ninfer_qwen3_6_jinja_vision_mapping_test` — six message shapes (image first, after a turn, in a tool result, after a tool result, two images in two turns) across both registered templates, asserting one placeholder per image, in order, each covering its `<|image_pad|>`, plus every message boundary mapped. 16 failures before, 12 renders
clean after.

`ninfer_qwen3_6_jinja_frontend_render_test` (84 renders), the froggeric render oracle and `ninfer_jinja_template_test` (33 contexts) stay green.

The template the deployed qwen3.8 artifact embeds is added as a fixture: the registry expects digest `c3cf9e34…`, while `tests/fixtures/frontend/reasoning_effort_chat_template.jinja` is a stand-in hashing `514d5304…`. That gap is why the oracle suite never saw this.