### PR TITLE
feat(sampling): post-thinking sampling, and atomic {KV + state} cache units

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ This fork targets **reliable 555k-context inference with 3 concurrent agentic se
 - **Froggeric v22.5 chat template**: executed from the template file with no-dangling-intent enforcement, effort aliases, leading system-message merge, tool-error tiering, and think-close variant handling.
 - **Tolerant tool-call recovery** (`--tolerant-tool-calls`): recovers complete Qwen calls with malformed wrappers.
 - **Reasoning-effort tier mapping**: High/Max map to XHigh instead of rejecting.
+- **Post-thinking sampling**: a thinking request switches to a dedicated lower-temperature preset
+  from the token after the model closes its reasoning block (e.g. temperature 1.0 while
+  reasoning, 0.2 for the answer). Registered per model; override with
+  `--post-thinking-temperature/-top-p/-top-k` or the request's `post_thinking` field.
 
 ### Monitoring and tooling
 
@@ -93,6 +97,43 @@ identity: `qwen36-nvfp4`, `qwen38-nvfp4`, `qwen36-groupwise-int`, `qwen38-groupw
 Use `qwen36-nvfp4` for Ostfralla and QUASAR artifacts that carry the Qwen3.6 NVFP4
 tensor layout (W8G32 embedding + NVFP4 quantization). The binding auto-detects
 per-layer layout differences (fused vs split GDN control, NVFP4 vs BF16 attention).
+
+### Post-thinking sampling
+
+Registered Qwen models carry a **post-thinking preset** (temperature 0.2, top-p 0.95,
+top-k 20). For a thinking request, the engine resolves the normal thinking preset at
+submission and switches to the post-thinking preset from the token after the model closes
+its reasoning block. The answer and tool calls are therefore sampled with the lower
+temperature while reasoning keeps the higher one. Non-thinking requests and models
+without a registered preset are unaffected.
+
+Override per request or per server:
+
+```bash
+# CLI: explicit post-thinking fields, or the combined form
+./build/apps/ninfer model.ninfer --prompt "..." \
+  --post-thinking-temperature 0.2 --post-thinking-top-p 0.95 --post-thinking-top-k 20
+#   --post-thinking-sampler temp=0.2,top_p=0.95,top_k=20
+
+# HTTP: optional post_thinking object (OpenAI Chat, OpenAI Responses, Anthropic Messages)
+curl http://127.0.0.1:8080/v1/chat/completions -H 'Content-Type: application/json' \
+  -d '{
+    "model": "qwen3.8-27b",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "temperature": 1.0,
+    "post_thinking": {"temperature": 0.2, "top_p": 0.95, "top_k": 20}
+  }'
+```
+
+Omitted `post_thinking` fields fall back to the model's registered preset; an omitted
+seed inherits the request's resolved seed. `--greedy` forces both phases to exact argmax.
+
+The lower emission temperature is a reliability setting rather than a quality one: see
+[the post-thinking temperature study](docs/maintainer/post-thinking-temperature.md) for the measured
+effect - neutral on accuracy across BFCL v4, AIME and IFBench, with reproducibility of long-form
+answers under load as the measurable contribution.
+See [docs/cli.md](docs/cli.md) and [docs/serving.md](docs/serving.md) for the full field
+list and ranges.
 
 
 ## Quick start
@@ -308,7 +349,8 @@ All registered model IDs support:
 - BF16, INT8 group-64, and row-scaled FP8 E4M3 KV storage;
 - offline causal-perplexity scoring with the same Text model and selectable KV storage;
 - private and shared exact-prefix reuse with Device/Host State and KV retention;
-- model-aware sampling defaults and explicit sampler overrides;
+- model-aware sampling defaults, explicit sampler overrides, and a registered post-thinking
+  preset that takes over from the token after the model closes its reasoning block;
 - OpenAI Responses Core, OpenAI Chat Completions, and Anthropic Messages, including streaming,
   tools, local response state, token counting, and usage accounting.
 

--- a/apps/cli/main.cpp
+++ b/apps/cli/main.cpp
@@ -266,6 +266,12 @@ int main(int argc, char** argv) {
 
         ninfer::RequestOptions request;
         request.execution.sampling                = cli.sampling;
+        request.execution.post_thinking_sampling  = cli.post_thinking_sampling;
+        // An explicit post-thinking seed wins; otherwise the request's seed carries over so both
+        // phases share one random stream.
+        if (!request.execution.post_thinking_sampling.seed) {
+            request.execution.post_thinking_sampling.seed = request.execution.sampling.seed;
+        }
         request.execution.requested_output_tokens = cli.max_new;
         request.execution.thinking.budget         = cli.thinking_budget;
         request.stop.token_ids                    = cli.stop_token_ids;

--- a/apps/cli/options.cpp
+++ b/apps/cli/options.cpp
@@ -87,6 +87,8 @@ std::string usage_text(const char* argv0) {
            "       [--stop-token-id N]... [--stop <text>]... [--reasoning-stop <text>]...\n"
            "       [--raw-output] [--print-token-ids] [--no-thinking] [--thinking-budget N]\n"
            "       [--reasoning-effort low|medium|xhigh] [--vision]\n"
+           "       [--post-thinking-temperature F] [--post-thinking-top-p F]\n"
+           "       [--post-thinking-top-k N] [--post-thinking-sampler temp=F,top_p=F,top_k=N]\n"
            "       [--no-cuda-graph]\n"
            "\n"
            "Streams answer content to stdout and reasoning plus diagnostics to stderr.\n"
@@ -100,6 +102,46 @@ std::string usage_text(const char* argv0) {
            " MiB of sizing headroom.\n"
            "Sampling defaults come from the loaded model and thinking mode; flags override "
            "individual fields.\n";
+}
+
+void apply_post_thinking_sampler(std::string_view spec, SamplingOverrides& out) {
+    std::size_t begin = 0;
+    while (begin < spec.size()) {
+        const std::size_t comma = spec.find(',', begin);
+        const std::string_view field =
+            spec.substr(begin, comma == std::string_view::npos
+                              ? std::string_view::npos
+                              : comma - begin);
+        const std::size_t equals = field.find('=');
+        if (equals == std::string_view::npos) {
+            throw std::invalid_argument("--post-thinking-sampler field missing '=': " +
+                                        std::string(field));
+        }
+        const std::string_view key   = field.substr(0, equals);
+        const std::string_view value = field.substr(equals + 1);
+        if (key == "temp") {
+            out.temperature = parse_float(std::string(value).c_str(), "post-thinking temp", 0.0F,
+                                          2.0F);
+        } else if (key == "top_p") {
+            out.top_p = parse_float(std::string(value).c_str(), "post-thinking top_p", 0.0F, 1.0F);
+        } else if (key == "top_k") {
+            const std::uint32_t top_k =
+                parse_u32(std::string(value).c_str(), "post-thinking top_k", true);
+            if (top_k > 20) { throw std::invalid_argument("post-thinking top_k must be in [0,20]"); }
+            out.top_k = static_cast<std::int32_t>(top_k);
+        } else if (key == "min_p") {
+            out.min_p = parse_float(std::string(value).c_str(), "post-thinking min_p", 0.0F, 1.0F);
+        } else if (key == "presence") {
+            out.presence_penalty = parse_float(std::string(value).c_str(), "post-thinking presence",
+                                              -2.0F, 2.0F);
+        } else if (key == "frequency") {
+            out.frequency_penalty = parse_float(std::string(value).c_str(), "post-thinking frequency",
+                                               -2.0F, 2.0F);
+        } else {
+            throw std::invalid_argument("unknown --post-thinking-sampler key: " + std::string(key));
+        }
+        begin = comma == std::string_view::npos ? spec.size() : comma + 1;
+    }
 }
 
 Options parse_options(int argc, char** argv) {
@@ -195,6 +237,18 @@ Options parse_options(int argc, char** argv) {
                 parse_float(value(arg), "frequency-penalty", -2.0F, 2.0F);
         } else if (arg == "--seed") {
             options.sampling.seed = parse_u64(value(arg), "seed");
+        } else if (arg == "--post-thinking-temperature") {
+            options.post_thinking_sampling.temperature =
+                parse_float(value(arg), "post-thinking-temperature", 0.0F, 2.0F);
+        } else if (arg == "--post-thinking-top-p") {
+            options.post_thinking_sampling.top_p =
+                parse_float(value(arg), "post-thinking-top-p", 0.0F, 1.0F);
+        } else if (arg == "--post-thinking-top-k") {
+            const std::uint32_t top_k = parse_u32(value(arg), "post-thinking-top-k", true);
+            if (top_k > 20) { throw std::invalid_argument("--post-thinking-top-k must be in [0,20]"); }
+            options.post_thinking_sampling.top_k = static_cast<std::int32_t>(top_k);
+        } else if (arg == "--post-thinking-sampler") {
+            apply_post_thinking_sampler(value(arg), options.post_thinking_sampling);
         } else if (arg == "--greedy") {
             options.greedy = true;
         } else {
@@ -228,7 +282,10 @@ Options parse_options(int argc, char** argv) {
     if (!options.enable_thinking && options.thinking_budget) {
         throw std::invalid_argument("--thinking-budget cannot be combined with --no-thinking");
     }
-    if (options.greedy) { options.sampling.temperature = 0.0F; }
+    if (options.greedy) {
+        options.sampling.temperature = 0.0F;
+        options.post_thinking_sampling.temperature = 0.0F;
+    }
     return options;
 }
 

--- a/apps/cli/options.h
+++ b/apps/cli/options.h
@@ -41,6 +41,9 @@ struct Options {
 
     // Omitted fields are resolved from the loaded model and rendered prompt mode by Engine.
     SamplingOverrides sampling;
+    // Overrides applied from the token after the model closes its reasoning block. Omitted
+    // fields fall back to the model's post-thinking preset.
+    SamplingOverrides post_thinking_sampling;
     bool greedy = false;
 };
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -205,6 +205,8 @@ The table lists executable defaults. The examples above select FP8 KV and MTP3.
 | `--presence-penalty F` | presence-penalty override | registered model/mode default |
 | `--frequency-penalty F` | frequency-penalty override | registered model/mode default (`0`) |
 | `--seed N` | sampling seed | `0` |
+| `--post-thinking-temperature F` / `--post-thinking-top-p F` / `--post-thinking-top-k N` | post-thinking phase overrides applied from the token after the model closes its reasoning block | model post-thinking preset |
+| `--post-thinking-sampler temp=F,top_p=F,top_k=N` | combined form of the three post-thinking overrides (also accepts `min_p`, `presence`, `frequency`) | model post-thinking preset |
 
 When a sampling flag is omitted, Engine selects the official general-task preset registered for
 the loaded model and the rendered prompt mode. The current presets are:
@@ -212,13 +214,18 @@ the loaded model and the rendered prompt mode. The current presets are:
 | Model | Prompt mode | Temperature | Top-p | Top-k | Min-p | Presence penalty |
 |---|---|---:|---:|---:|---:|---:|
 | Qwen3.6-27B | thinking | `1.0` | `0.95` | `20` | `0` | `0` |
+| Qwen3.6-27B | post-thinking | `0.2` | `0.95` | `20` | `0` | `0` |
 | Qwen3.6-27B | non-thinking | `0.7` | `0.80` | `20` | `0` | `1.5` |
 | Qwen3.8-27B | thinking | `1.0` | `0.95` | `20` | `0` | `0` |
+| Qwen3.8-27B | post-thinking | `0.2` | `0.95` | `20` | `0` | `0` |
 | Qwen3.8-27B | non-thinking | `0.7` | `0.80` | `20` | `0` | `1.5` |
 | Qwen3.6-35B-A3B | thinking | `1.0` | `0.95` | `20` | `0` | `1.5` |
+| Qwen3.6-35B-A3B | post-thinking | `0.2` | `0.95` | `20` | `0` | `1.5` |
 | Qwen3.6-35B-A3B | non-thinking | `0.7` | `0.80` | `20` | `0` | `1.5` |
 
-Frequency penalty is `0` in every registered preset. Task-specific profiles such as Qwen's
+Frequency penalty is `0` in every registered thinking/post-thinking preset. The post-thinking
+phase applies from the token after the model closes its reasoning block; it is not tracked under
+`--raw-output`, where channel detection is disabled. Task-specific profiles such as Qwen's
 precise-coding profile use explicit sampling overrides.
 
 Repeat `--stop-token-id`, `--stop`, or `--reasoning-stop` to add stop conditions. Use

--- a/docs/maintainer/post-thinking-temperature.md
+++ b/docs/maintainer/post-thinking-temperature.md
@@ -1,0 +1,252 @@
+# Post-thinking sampling temperature: measured behaviour, and the case for deferring ReSET
+
+Scope: the post-thinking sampler (the sampling parameters that take effect once the model closes its
+reasoning block), measured on Qwen3.8-27B QUASAR NVFP4 on one RTX 5090 at Git `b802c515`. This note
+records seven experiments across three accuracy benchmarks plus a temperature-response sweep and a
+reproducibility measurement, together with a measurement defect discovered on the way, the literature
+position, and the resulting recommendation.
+
+"ReSET" throughout names a published decoding-time temperature-control method for NVFP4 reasoning
+models - Lee et al., [arXiv:2606.13233](https://arxiv.org/abs/2606.13233) - and the final section
+assesses whether pursuing it is worthwhile in this setup.
+
+## Summary
+
+- The knob changes **which** tokens are emitted (90.3% of plans produce four different emissions
+  across a temperature ladder) but changes **no** aggregate: answer length, tool-call validity,
+  prose degeneration and accuracy are all flat.
+- Accuracy: no measurable effect on any of three benchmarks - BFCL v4 tool calling (n=1240 paired,
+  McNemar p=0.79), AIME (60 problems per arm, inside a +/-4 pp band), IFBench (300 samples per arm,
+  0.2 and 1.0 identical).
+- One measurable benefit: the **reproducibility** of long free-form answers under numerical-route
+  variation (100% -> 62.5% distinct answers at identical route variation; mean pairwise similarity
+  0.389 -> 0.629). Short structured output is insensitive at every temperature.
+- Conclusion: the shipped `post_thinking` temperature of 0.2 is a **reliability knob, not a quality
+  knob**, and it only acts on long output. It is not justified as an accuracy improvement by any
+  measurement we have.
+- A faithful ReSET-style experiment should be **deferred** for this use case and setup: the damage
+  pool it targets is not observable on our stack, and our artifact is already quantization-aware
+  trained. Details in the final section.
+
+## Measurement methodology, and a defect we found
+
+The sampler is a pure positional hash of `(seed, position, purpose, sub)` with no mutable RNG state,
+which invites a paired design: same seed and same thinking parameters should give a bit-identical
+reasoning block, leaving the emission phase as the only difference between arms. Two controls show
+that this is **not** safe in this serving configuration.
+
+| control: one identical request repeated, seed 42 | distinct reasoning blocks | distinct emission |
+|---|---:|---:|
+| sequential, one request in flight | 1 | 1 |
+| concurrent, two requests in flight | 3 | 1 |
+
+Identical requests reproduce only when the execution route is identical. Prefix caching does the same
+thing: in 28 of 150 ladder groups only the first (cold-prefill) request differed while the three
+cache-warm ones agreed, and two of six prompts returned different reasoning for identical requests
+across rounds even at concurrency 1.
+
+Consequences for this document:
+- the BFCL A/B is a valid comparison of two configurations but **not** a token-paired measurement;
+- every paired claim below is conditioned on identical reasoning, and where a pair is not comparable
+  it is excluded rather than silently averaged in.
+
+This is the known **batch-invariance** problem (kernels whose result depends on batch composition),
+not an RNG problem: batch-invariant kernels give perfect reproducibility at roughly a 60% throughput
+cost.
+
+## Experiment 1 - BFCL v4 tool calling A/B (n=1240 paired samples)
+
+Two arms on the QUASAR artifact at temperature 1.0, identical thinking parameters and seed, differing
+only in `post_thinking`: `emit@1.0` mirrors the thinking sampler (one preset for the whole
+generation, the pre-feature behaviour) and `emit@0.2` lets the registered preset govern the emission
+phase. All five subsets at full population, fresh server per arm.
+
+| metric | `emit@1.0` | `emit@0.2` |
+|---|---:|---:|
+| overall accuracy | 86.0% (1067/1240) | 85.8% (1064/1240) |
+| discordant samples | - | 55 (26 fixed, 29 broken) |
+| exact McNemar p | - | 0.79 |
+| invalid emissions | 173/1240 | 176/1240 |
+
+The discordant-pair interval bounds any true difference to roughly +/-1.2 pp. The error-type
+histograms also match category for category (`irrelevance_error:decoder_success` 42/42,
+`ast_decoder:decoder_failed` 23/24, `value_error:string` 12/12, parallel-checker mismatches 7/8 and
+5/5, `type_error:nested` 4/4). Residual failures are semantic - missing or wrong function, bad
+argument - not temperature-sensitive formatting, so a colder emission has nothing to repair.
+
+## Experiment 2 - output-level comparison on the same data
+
+Comparing the emitted call sample-by-sample, then canonicalising it (function name plus sorted
+arguments, whitespace-insensitive):
+
+| quantity | count | share |
+|---|---:|---:|
+| emitted text differs | 474 | 38.2% |
+| call structure differs | 104 | 8.4% |
+| call differs but scores identically | 66 | 63.5% of call changes |
+| call differs and score changes | 38 | 36.5% of call changes |
+
+The benchmark discards most of what the knob produces, which is why an accuracy-only view reports a
+null. A further 17 score changes (all in `multi_turn_base`) were not explained by any call-structure
+difference; that subset's scoring depends on execution results across turns, so its decomposition is
+partial.
+
+## Experiment 3 - emission-temperature response sweep
+
+30 prompts (20 tool-call, 10 free-form) x 5 seeds x emission temperature {0.0, 0.2, 0.7, 1.0}, with
+the thinking phase frozen at 1.0 and every request issued sequentially so the route is stable.
+
+Conditioned on identical thinking:
+
+| pair | samples differing | mean character similarity |
+|---|---:|---:|
+| greedy vs 0.2 | 90.2% | 0.793 |
+| greedy vs 1.0 | 97.3% | 0.713 |
+| 0.2 vs 1.0 | 97.2% | 0.705 |
+
+**90.3% of plans produce four distinct emissions across the ladder** - the knob is not inert. Every
+aggregate, however, is flat:
+
+| property | result across the ladder |
+|---|---|
+| emission length | median 62 tokens at every temperature; 0% truncation |
+| tool-call validity | 83-84 of 100 at every temperature |
+| prose degeneration | max repeated 4-gram 1.42 (greedy) to 1.30 (1.0) - no degeneration anywhere |
+| dispersion across seeds | mean distinct fraction 0.980 (0.0) to 0.993 (1.0) |
+
+## Experiment 4 - reproducibility of the final answer under route variation
+
+5 prompts x 3 seeds x 8 repetitions per temperature, with two requests kept in flight so the route
+varies, and the condition order rotated each round.
+
+| prompt | `emit@0.2`: route / answer variation | `emit@1.0`: route / answer variation | similarity 0.2 -> 1.0 |
+|---|---|---|---|
+| long free-form prose | 0.208 / 0.625 | 0.208 / 1.000 | 0.629 -> 0.389 |
+| short JSON object | 0.208 / 0.208 | 0.208 / 0.250 | 0.987 -> 0.979 |
+| short tool call | 0.208 / 0.125 | 0.208 / 0.125 | 1.000 -> 1.000 |
+
+At **identical** route variation (0.208 distinct reasoning per 8 in both arms), the cold emission made
+long-form answers 37.5 percentage points more reproducible, and materially more similar. Short
+structured output was insensitive at both temperatures. Aggregated over prompts: 0.342 distinct
+answers per 8 repetitions at 0.2 against 0.425 at 1.0.
+
+This is the only positive effect we were able to measure for the feature, and it is invisible to any
+accuracy benchmark.
+
+## Experiment 5 - AIME emission ladder (60 problems per arm)
+
+| arm | accuracy | no boxed answer | multiple boxes | malformed box | median answer-phase tokens |
+|---|---:|---:|---:|---:|---:|
+| `emit@0.0` | 90.00% | 8.3% | 3.3% | 0% | 6,473 |
+| `emit@0.2` | 90.00% | 8.3% | 1.7% | 0% | 5,887 |
+| `emit@1.0` | 86.67% | 6.7% | 1.7% | 0% | 6,473 |
+
+The apparent +3.33 pp cold advantage is two problems against a +/-4.2 pp band, and the formatting
+metrics move the *other* way (1.0 produced the fewest missing boxes and the most clean integers).
+**No malformed symbolic answers anywhere.** The dominant failure is emitting no answer box at all,
+which is a termination/formatting failure that no emission temperature fixed, and none of those cases
+were truncations.
+
+## Experiment 6 - IFBench emission ladder (300 samples per arm)
+
+Long constrained output, machine-verifiable constraints
+([IFBench](https://arxiv.org/abs/2507.02833)). Primary metric is `prompt_level_strict`.
+
+| arm | prompt strict | inst strict | prompt loose | inst loose |
+|---|---:|---:|---:|---:|
+| `emit@0.0` | 0.6333 | 0.6683 | 0.6733 | 0.7067 |
+| `emit@0.2` | 0.6367 | 0.6667 | 0.6800 | 0.7083 |
+| `emit@1.0` | 0.6367 | 0.6733 | 0.6667 | 0.7033 |
+
+`emit@0.2` and `emit@1.0` are identical on the primary metric; greedy is one sample lower; all four
+metrics sit within 1.3 pp. A third benchmark, a third null - including for constraint compliance,
+which was the most plausible place for a cold emission to help.
+
+Open observation: our absolute level is 63-64% where the model card records 77.00% for IFBench. That
+card figure was measured on the upstream artifact this fork cannot load, at different sampling, so it
+is not like-for-like - but IFBench is part of our suite and the size of the gap deserves its own
+investigation.
+
+## Experiment 7 - controlled artifact comparison
+
+QUASAR (quantization-aware trained) against Ostfralla, with the **same** chat template (CLI froggeric
+v22.5 for both), the **same** sampling (1.0/0.95/20), the **same** emission (post_thinking mirroring
+the thinking sampler) and a fresh server per arm. Only the artifact differs.
+
+| artifact | AIME 2025 | AIME 2026 | total |
+|---|---:|---:|---:|
+| QUASAR (QAT) | 28/30 | 27/30 | **55/60 = 91.7%** |
+| Ostfralla | 28/30 | 24/30 | 52/60 = 86.7% |
+
+QUASAR is 5 pp ahead, which is under one standard error at n=60: **no significant artifact difference
+under controlled conditions.**
+
+AIME results for these artifacts depend on the serving configuration rather than on the artifact
+alone. The same Ostfralla artifact scored 59/60 when served with its own embedded chat template at a
+0.7 thinking temperature, and 52/60 here with the CLI froggeric v22.5 template at 1.0. Artifact AIME
+numbers are therefore only comparable when the template and sampling settings are identical, which is
+why this comparison pins both.
+
+## Literature position
+
+- Lee, Janghwan Lee, Yoo, Kim, Ryu, Ryu and Choi, *ReSET: Accurate Latency-Critical NVFP4 Reasoning
+  via Step-Aware Temperature Scaling* ([arXiv:2606.13233](https://arxiv.org/abs/2606.13233),
+  [code](https://github.com/aiha-lab/ReSET)): step-aware, entropy-gated decoding temperature for NVFP4
+  reasoning models. Cold for low-entropy symbolic tokens, temperature *above* the default for
+  high-uncertainty steps (because NVFP4 over-concentrates them), up to roughly +2 points over an NVFP4
+  baseline, with `T_low` calibrated per (model, task). Our knob is the uniform special case and cools
+  the uncertain content too - which is precisely what ReSET says not to do. **Our nulls therefore do
+  not falsify ReSET**; they falsify the narrower claim that uniformly cooling the emission phase
+  improves accuracy or format compliance.
+- Wu, Mirhoseini and Tambe, *On the Role of Temperature Sampling in Test-Time Scaling* (Stanford,
+  [arXiv:2510.02611](https://arxiv.org/abs/2510.02611)): different temperatures solve different problem
+  subsets, and multi-temperature scaling added +7.3 Pass@All over single-temperature scaling. This
+  supports the concern that a fixed cold emission narrows the explored temperature dimension for
+  finalisation - though the reasoning phase, which carries most of the diversity, is untouched in our
+  design.
+- Salah and Muneer, *Temperature-Dependent Performance of Prompting Strategies in Extended Reasoning
+  Large Language Models* ([arXiv:2604.08563](https://arxiv.org/abs/2604.08563)): the benefit of extended
+  reasoning grows from 6x at T=0.0 to 14.3x at T=1.0, consistent with keeping the thinking phase hot.
+- Thinking Machines Lab, *[Defeating Nondeterminism in LLM
+  Inference](https://thinkingmachines.ai/blog/defeating-nondeterminism-in-llm-inference/)*: the root
+  cause of our irreproducibility, and the reason the paired design had to be abandoned.
+
+## Recommendation
+
+**Feature.** Keep the mechanism and the override, treat the preset value as a reliability setting, and
+stop describing it as a quality improvement. Concretely, the evidence supports one of:
+
+1. keep `post_thinking` at 0.2 and document it as a reproducibility knob for long output, on the
+   grounds that it costs nothing measurable on three benchmarks and helps stability under route
+   variation; or
+2. default `post_thinking` to mirroring the thinking sampler, so the shipped behaviour is the one we
+   can defend, and expose 0.2 as an explicit opt-in for reproducibility-sensitive deployments.
+
+Option 2 is the more honest default given that the only measured effect is variance reduction, and
+that the test-time-scaling literature shows narrow temperature coverage costs accuracy on hard
+problems. Either way the reasoning phase should stay at 1.0, which is both what ReSET prescribes for
+high-uncertainty content and what the extended-reasoning temperature study supports.
+
+**ReSET-style entropy-gated temperature: defer.** The justification for building it is missing on our
+stack:
+
+- the damage pool it targets is not observable - the malformed-symbolic-answer rate is 0% on every
+  artifact and every emission setting we measured, and the one symbolic failure we do see (no answer
+  box at all) is unaffected by emission temperature;
+- our artifact is quantization-aware trained, which is the mitigation ReSET itself names for that
+  damage, and the controlled comparison shows no artifact-quality gap that could stand in for it;
+- a faithful test needs the gated policy implemented (a feature, not a flag), per-task `T_low`
+  calibration, and a benchmark with power - AIME at n=60 gives +/-4 pp, far too coarse for a ~2-point
+  effect;
+- and the uniform version of the idea measurably does nothing on three benchmarks.
+
+Revisit only if (a) we move to a post-training-quantized artifact or a lower-precision path and can
+observe the symbolic damage reappearing, or (b) a user-visible failure is traced specifically to
+answer-phase sampling.
+
+**Separate workstream: batch invariance.** That identical `(prompt, seed, params)` does not reproduce
+across route changes is independent of this feature, and has wider consequences: evaluation runs are
+not exactly repeatable, paired evaluation designs are unsound unless the route is held constant, and
+any assumption that a fixed seed makes a cached response reproducible is false. Options are
+batch-invariant kernels at a significant throughput cost, or accepting and documenting the variance.
+This should be tracked on its own.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -22,7 +22,9 @@ Tested Git revisions:
   `b3d4d0f50b868711c62432bbd68e746217a2f49a`;
 - Qwen3.6-27B groupwise-int MTP3: `5ea3242a206cdb0c4c1beaeb9d8a3048e6248423`;
 - Qwen3.6-35B-A3B MTP0 and Qwen3.6-27B groupwise-int MTP0:
-  `0795169393cab0f2c16246d4bac20dee735dc2a4`.
+  `0795169393cab0f2c16246d4bac20dee735dc2a4`;
+- Qwen3.8-27B QUASAR post-thinking sampler BFCL v4 tool-calling A/B:
+  `b802c515a3aa60121435adf169f686bdd4a045a6`.
 
 The Qwen3.6 measurements characterize its three registered artifact profiles independently on one
 NVIDIA GeForce RTX 5090. They cover long-context prefill and baseline decode with speculative
@@ -633,3 +635,73 @@ Each category contains three fixtures and five seeds per fixture, for 15 samples
 
 The baseline and speculative-decode suites intentionally measure different supported workloads.
 No per-scenario baseline/speculative speedup is reported.
+
+## Post-thinking sampler: BFCL v4 tool-calling A/B (`qwen3_8_27b` QUASAR)
+
+The post-thinking sampler changes the sampling parameters once the model closes its reasoning block,
+so the phase it governs is the emitted answer rather than the reasoning. This campaign asks whether
+that switch changes tool-calling quality, and in which direction.
+
+Both arms used `seed 42` and identical thinking parameters. The sampler is a pure positional hash of
+`(seed, position, purpose, sub)` with no mutable RNG state, so identical seeds and parameters reproduce
+the same tokens **only when the execution route is identical**, and this engine is not batch-invariant:
+eight sequential identical requests reproduce exactly, while eight with two in flight produce three
+distinct reasoning blocks, and cold-prefill versus cache-warm routes differ on three of six prompts.
+The arms therefore ran with reasoning blocks that were not bit-identical, so this compares two
+configurations rather than pairing tokens, and part of the observed discordance is route noise. The
+[post-thinking temperature study](maintainer/post-thinking-temperature.md) documents the control and
+re-states its paired results conditioned on identical reasoning.
+
+- `emit @ 1.0` sets `post_thinking` to mirror the thinking sampler (temperature 1.0, top-p 0.95,
+  top-k 20), so a single preset governs the whole generation. This reproduces the behaviour that
+  existed before the feature.
+- `emit @ 0.2` sends no `post_thinking` override, so the registered preset (temperature 0.2,
+  top-p 0.95, top-k 20) governs the phase after the reasoning block closes.
+
+Both arms ran at Git revision `b802c515` on the QUASAR NVFP4 artifact through NInfer's
+OpenAI-compatible serving route with thinking enabled, MTP=5, NVFP4 KV, a 262,144-token context
+limit, the froggeric v22.5 template and `--weights-profile qwen36-nvfp4`. Server defaults were
+temperature 1.0, top-p 0.95, top-k 20, seed 42. Each arm ran on a fresh server, so neither could
+inherit the other's cached prefixes. Every subset ran at full population and all 1240 samples
+completed and were scored in both arms. BFCL's reference protocol runs greedy; this campaign samples
+deliberately, because a post-thinking switch only exists while sampling is active.
+
+Because the arms are paired sample-by-sample, the discriminating quantity is the discordant pair
+count - how many samples `emit @ 0.2` fixes versus breaks - with an exact two-sided McNemar p-value.
+
+| Subset | Samples | `emit @ 1.0` | `emit @ 0.2` | Delta | fixed | broken | p |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `simple_python` | 400 | 92.5% (370/400) | 92.3% (369/400) | -0.3 pp | 3 | 4 | 1.00 |
+| `multiple` | 200 | 93.5% (187/200) | 92.5% (185/200) | -1.0 pp | 1 | 3 | 0.63 |
+| `parallel` | 200 | 90.0% (180/200) | 89.5% (179/200) | -0.5 pp | 0 | 1 | 1.00 |
+| `irrelevance` | 240 | 82.5% (198/240) | 82.5% (198/240) | 0.0 pp | 2 | 2 | 1.00 |
+| `multi_turn_base` | 200 | 66.0% (132/200) | 66.5% (133/200) | +0.5 pp | 20 | 19 | 1.00 |
+| **All subsets** | **1240** | **86.0% (1067/1240)** | **85.8% (1064/1240)** | **-0.2 pp** | **26** | **29** | **0.79** |
+
+The difference is not significant. Of 1240 paired samples, 55 were discordant: `emit @ 0.2` fixed 26
+and broke 29, a net of -3 samples (-0.2 pp), p = 0.79. The interval implied by the discordant pairs
+bounds any true difference to roughly ±1.2 pp. At this sample size the post-thinking switch neither
+improves nor degrades BFCL v4 tool-calling quality.
+
+The mechanism is visible in the failure modes, which are unchanged. Emission validity was 173 invalid
+samples of 1240 under `emit @ 1.0` and 176 under `emit @ 0.2`, and the error-type histograms match
+category for category: `irrelevance_error:decoder_success` 42 / 42, `ast_decoder:decoder_failed`
+23 / 24, `value_error:string` 12 / 12, `parallel_function_checker_no_order:cannot_find_match` 7 / 8,
+`value_error:others` 6 / 7, `parallel_function_checker_no_order:wrong_count` 5 / 5, and
+`type_error:nested` 4 / 4. The residual failures are semantic - a missing or wrong function, or an
+argument error - rather than temperature-sensitive syntactic breakage. The structured call is already
+reliable at temperature 1.0, so a colder emission phase has nothing to repair.
+
+The practical consequence for serving configuration: lowering the sampling temperature only for the
+phase after the reasoning block is quality-neutral on tool calling. That is what makes it safe to run
+the thinking phase at the official temperature instead of compromising it downward with a single
+global value.
+
+This campaign is part of a wider study of the post-thinking temperature, spanning an AIME
+emission ladder (60 problems per arm), an IFBench emission ladder (300 samples per arm), a
+temperature-response sweep, a reproducibility measurement under route variation, and a controlled
+QUASAR-versus-Ostfralla artifact comparison. All three accuracy benchmarks are null; the only
+measurable effect is reproducibility of long-form output under route variation. See
+[the post-thinking temperature study](maintainer/post-thinking-temperature.md) for the full results
+and the recommendation, including why
+[ReSET](https://arxiv.org/abs/2606.13233)-style entropy-gated temperature is deferred.

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -99,6 +99,9 @@ The endpoint supports:
   processing without generation;
 - `temperature`, `top_p`, presence/frequency penalties, and signed integer `seed`;
 - the compatible `top_k` (`0..20`) and `min_p` (`0..1`) sampler extensions;
+- an optional `post_thinking` object (`temperature`, `top_p`, `top_k`, `min_p`, penalties, `seed`)
+  whose fields apply from the token after the model closes its reasoning block; omitted fields fall
+  back to the model's post-thinking preset, and it has no effect unless thinking is enabled;
 - up to four non-empty stop strings, applied to both reasoning and answer output;
 - `n:1`, text-only `modalities`, and `response_format: {"type":"text"}`;
 - non-streaming responses and server-sent event streams;
@@ -324,6 +327,7 @@ wire response contains typed `output` Items.
 | `store` | boolean, default `true`; controls local retrieval and continuation state |
 | `temperature` | finite number in `[0,2]` |
 | `top_p` | finite number in `[0,1]` |
+| `post_thinking` | optional object (`temperature`, `top_p`, `top_k`, `min_p`, penalties, `seed`); fields apply from the token after the model closes its reasoning block, with omitted fields falling back to the model's post-thinking preset; no effect unless thinking is enabled |
 | `metadata` | at most 16 string pairs; keys at most 64 characters and values at most 512 |
 | `client_metadata` | Codex client extension; an object or `null`, accepted as opaque tracing metadata with no generation effect |
 | `reasoning.effort` | `none` disables thinking; `low`, `medium`, or `xhigh` selects an effort exposed by the loaded chat template; `minimal`, `high`, and `max` return `reasoning_effort_not_supported` for the registered templates |
@@ -579,7 +583,14 @@ enabled.
 `max_tokens` is optional for local clients and otherwise uses `--default-max-tokens`; a positive
 value is the complete output budget. `max_tokens:0` is rejected because NInfer does not expose a
 completed zero-output cache-prewarm lifecycle. `temperature`, `top_p`, `top_k`, and
-`stop_sequences` enter Engine execution. A matched custom stop is returned as
+`stop_sequences` enter Engine execution. The `post_thinking` NInfer extension object
+(`temperature`, `top_p`, `top_k`) applies its fields from the token after the model closes its
+reasoning block; omitted fields fall back to the model's post-thinking preset, and it has no
+effect unless thinking is enabled. The preset default lowers only the emission phase. A 1240-sample
+BFCL v4 campaign found that quality-neutral for tool calling, and AIME and IFBench agree; the
+measurable contribution is reproducibility of long-form answers under load. See
+[the post-thinking A/B](performance.md#post-thinking-sampler-bfcl-v4-tool-calling-ab-qwen3_8_27b-quasar)
+and [the post-thinking temperature study](maintainer/post-thinking-temperature.md). A matched custom stop is returned as
 `stop_reason:"stop_sequence"` together with the actual `stop_sequence`; context exhaustion returns
 `model_context_window_exceeded`.
 

--- a/include/ninfer/types.h
+++ b/include/ninfer/types.h
@@ -146,6 +146,20 @@ enum class SamplingMode : std::uint8_t {
     NonThinking,
 };
 
+// Generation phase for sampling-preset selection. PostThinking is only reachable from Thinking:
+// it applies from the token after the model closes its reasoning block.
+enum class SamplingPhase : std::uint8_t {
+    Thinking,
+    PostThinking,
+    NonThinking,
+};
+
+// Phase a request starts in, derived from whether thinking is enabled.
+[[nodiscard]] constexpr SamplingPhase initial_sampling_phase(SamplingMode mode) noexcept {
+    return mode == SamplingMode::Thinking ? SamplingPhase::Thinking
+                                          : SamplingPhase::NonThinking;
+}
+
 // Immutable model-owned values used when a request does not override a sampling field. Seed is
 // deliberately excluded: it is an execution choice rather than a model recommendation.
 struct SamplingPreset {
@@ -159,10 +173,22 @@ struct SamplingPreset {
 
 struct ModelSamplingDefaults {
     SamplingPreset thinking;
+    SamplingPreset post_thinking;
     SamplingPreset non_thinking;
+    // Set by a model that registers a real post-thinking preset. The Engine switches to
+    // post_thinking sampling only when this is true and thinking is enabled.
+    bool has_post_thinking = false;
 
-    [[nodiscard]] constexpr const SamplingPreset& for_mode(SamplingMode mode) const noexcept {
-        return mode == SamplingMode::Thinking ? thinking : non_thinking;
+    [[nodiscard]] constexpr const SamplingPreset& for_phase(SamplingPhase phase) const noexcept {
+        switch (phase) {
+            case SamplingPhase::Thinking:
+                return thinking;
+            case SamplingPhase::PostThinking:
+                return post_thinking;
+            case SamplingPhase::NonThinking:
+                return non_thinking;
+        }
+        return non_thinking;
     }
 };
 
@@ -216,6 +242,9 @@ struct ThinkingControlOptions {
 
 struct ExecutionOptions {
     SamplingOverrides sampling;
+    // Overrides that apply from the token after the model closes its reasoning block. Omitted
+    // fields fall back to the model's post_thinking preset.
+    SamplingOverrides post_thinking_sampling;
     std::uint32_t requested_output_tokens = 0;
     bool allow_prefix_reuse               = true;
     ThinkingControlOptions thinking;

--- a/plan.md
+++ b/plan.md
@@ -13,6 +13,46 @@
 > - the A/B leak battery now has a permanent no-tools condition (D_notools)
 >   verified RECOVERED end-to-end
 
+## Standing plan — a cache unit is {KV + state}, atomically (invariant for every phase)
+
+A context-cache unit is **the attention KV and the GDN recurrent state together**.
+It is captured, retained, evicted and restored as ONE indivisible unit. Never store,
+evict, retain, budget or restore either half on its own. This overrides any earlier
+text in this plan that describes them as separately storable items.
+
+Why (hybrid topology): the KV covers only the attention (softmax) layers — 7 of 28 in
+the Qwen3.6-27B configuration this plan targets, with the other 21 being GDN/SSM —
+while the ~150 MB state image carries the GDN recurrent state. The split is
+model-specific (the Qwen3.8-27B production configuration is 16 attention of 64); the
+invariant is not. Resuming at position N requires BOTH halves, and neither half is
+independently useful:
+
+- **KV without state cannot resume**, and is not "cheaper than losing both": the
+  attention K/V at position p depends on the GDN layers' output at p, so attention
+  KV is not independently recomputable. Any recompute is a full prefix pass, which
+  rebuilds the GDN state as a by-product and regenerates the KV being kept.
+- **State without KV can only resume while that KV is still device-resident**, so it
+  is not a durable unit and must not be a stored/retained form.
+
+Therefore:
+
+- a partially-retained unit is a **bug, not a degraded cache**: it wastes host memory
+  and it is a correctness hazard, because prefix matching can select it and then
+  restore with a missing half, silently producing a wrong continuation;
+- eviction removes a **whole unit** — there is no "state-only" or "KV-only" victim class;
+- the host budget accounts a unit's **full size** (KV pages + state image) as one number;
+- "which half is expensive" is never an eviction criterion, because the halves have no
+  independent value.
+
+- eviction is **cost-aware, not strict LRU**: re-prefill cost scales with the unit's
+  context length, so reclaim the SMALLEST complete units first and hold on to recent
+  large caches — re-prefilling a big context is far more expensive. Recency is only a
+  tie-breaker between units of comparable size.
+
+Consequences for the host-KV safety net: entries are atomic; never create a partial
+entry; reclaim any pre-existing partial entry first; then reclaim by re-prefill cost
+(smallest unit first, recent large units kept), with recency as the tie-breaker.
+
 ## Context: the template file is a digest label, not executable behavior
 
 Verified state (2026-09-10):
@@ -239,15 +279,33 @@ allocation failures) is **causing the fragmentation it was meant to solve**:
 - 278 FALLBACK (state-only) events as a direct consequence
 - 1 bad_alloc (caught by WORKER OOM handler, server survived)
 
-**Root cause:** The arena allocator does not coalesce adjacent free regions.
-It appears to use a simple free-list or bump allocator that fragments under
-multi-size allocation patterns. The scatter-gather workaround creates the
-multi-size pattern that triggers fragmentation.
+**Root cause (corrected, verified against the deployed tree):** This is NOT a
+missing-coalescing bug. `HostKVArena::insert_free_extent` has coalesced
+adjacent free extents on every free since the safety net landed (2026-08-24),
+and the journal evidence above was collected from a build that includes it.
+The real mechanism is external fragmentation: large live spill entries
+(6-12.5GB each) interleaved with small live entries partition the free space
+into non-adjacent extents, and coalescing can only merge adjacent free
+regions — it cannot merge across a live block. When no single extent is large
+enough, the single-allocation path fails despite sufficient total free. The
+scatter-gather workaround then allocates across multiple extents; when those
+allocations are freed they add more live regions, so under churn the loop is
+self-reinforcing (Finding A's feedback chain holds, driven by live-entry
+interleaving rather than a missing coalesce).
 
-**Fix needed:** Arena allocator must coalesce adjacent free blocks (like a
-proper malloc) or implement compaction when free space is fragmented below
-a threshold. Alternatively, use a slab/buddy allocator that naturally
-avoids fragmentation for power-of-two allocation sizes.
+**Fix needed:** Coalescing is not the fix — it already exists and is not the
+gap. The real options, in order of directness:
+1. **Compaction:** when the fragmentation ratio (largest free extent / total
+   free) drops below a threshold, relocate live extents to the back of the
+   arena (copy + repoint) so free space re-merges into one contiguous
+   region. This is the only option that can fix external fragmentation
+   caused by live entries.
+2. **Uniform entry sizes:** make spill entries smaller and uniform so free
+   holes fit each other — the Level 1 "drop backend_kv" change below does
+   exactly this (12.5GB -> 6.2GB entries, half the size and more uniform).
+3. **Buddy/slab allocator:** naturally avoids fragmentation for
+   power-of-two sizes, but is a larger rewrite for a problem 1+2 already
+   address.
 
 ### Finding B — evict-smallest evicts only ONE entry
 
@@ -280,13 +338,74 @@ loses KV and causes re-prefills. The bad_alloc at the end of this chain
 was caught by the OOM handler (server survived), but the re-prefills
 (278 FALLBACK events) are the real cost.
 
-### Verification after fix
+### Fragmentation measurement — extend the existing `/stats` endpoint
 
-- Arena should reach 0 single-allocation failures when free >= need
-- Scatter-gather should only fire for genuine large allocations (>50% arena)
-- State-only FALLBACK should only fire when arena is genuinely full
-  (total used >= 90% of capacity), not when fragmented
-- evict-smallest should free enough space for the new allocation in one pass
+No new endpoint: `/stats` (`src/serve/stats_json.cpp`) already exposes
+`host_kv_capacity_bytes` / `host_kv_occupied_bytes`. Add fragmentation
+fields so the fix is measured instead of log-grepped.
+
+Instantaneous (into `MemorySummary`):
+- `host_kv_free_bytes`
+- `host_kv_largest_free_extent_bytes`
+- `host_kv_free_extent_count`
+- `host_kv_fragmentation_ratio` = largest extent / total free (1.0 = one
+  contiguous extent; lower = more shredded). The arena already tracks
+  `free_extents_`; this is a small read-only accessor.
+
+Cumulative counters (plumbed into `RuntimeStats`, incremented at the spill
+path in `program_impl.h`, which today only `fprintf(stderr)`s):
+- `host_kv_single_alloc_failures`
+- `host_kv_scatter_gather_allocations` and `host_kv_scatter_gather_extents`
+  (total extents across all scatter-gather allocations)
+- `host_kv_state_only_fallbacks`
+- `host_kv_evictions` (evict-smallest invocations)
+
+Land the metrics first, before the allocator fix: they are additive and
+give us the "before" baseline immediately.
+
+### Verification after fix (quantified against the metrics above)
+
+- `host_kv_single_alloc_failures` with `host_kv_free_bytes >= need` = 0
+  (incident baseline: 144)
+- `host_kv_scatter_gather_allocations` only fire for genuine large
+  allocations (need > 50% of arena capacity); otherwise 0
+- `host_kv_state_only_fallbacks` only when total used >= 90% of capacity
+  (incident baseline: 278 at ~50% occupancy)
+- evict-smallest frees enough space for the new allocation in one pass
+  (`host_kv_evictions` does not climb to drain the safety net)
+- `host_kv_fragmentation_ratio` stays at or above 0.9 during the evaluation
+  run
+
+### Evaluation — demonstrate the defrag fix in a real scenario
+
+Run the same pressure workload against pre-fix and post-fix builds and
+compare the counters above.
+
+Workload (reproduces the production shape that triggered the incident):
+- one long multi-turn thinking session, 371k tokens / ~1000 messages
+  (drives repeated 6-12.5GB checkpoint spills), plus several small
+  interleaved sessions (~5k tokens each) so the arena holds mixed-size
+  live entries — the exact allocation pattern that produced the 144
+  single-alloc failures and 278 FALLBACKs.
+- 30GB arena, same seed, thinking with `--preserve-reasoning` on.
+
+Method:
+1. Pre-fix build (metrics only): run the workload, poll `/stats` through
+   the run; record worst-case `host_kv_fragmentation_ratio` and the four
+   cumulative counters.
+2. Post-fix build: identical run.
+3. Compare. Pass = all four verification criteria hold in the post-fix run
+   and fail (as in the incident) in the pre-fix run.
+
+Configurations: pre-fix, fix-only, fix + Level 1 (drop `backend_kv`) — the
+third isolates how much of the improvement comes from uniform entry sizes
+versus the allocator change itself.
+
+Fast regression: a `HostKVArena` unit test that replays the mixed-size
+allocate/free sequence (interleaved 6GB / 2MB shapes) and asserts 0
+single-alloc failures with sufficient total free and a fragmentation ratio at
+the threshold. CI-runnable without a GPU; the real-scenario run is the
+end-to-end evidence, the unit test keeps it in the suite.
 
 
 ## Architecture Optimization — Exploit Hybrid SSM+Attention Topology (2026-09-10)
@@ -330,9 +449,24 @@ stores per-token transition records that allow "replaying" GDN computation from 
 arbitrary position. This is useful for branching from a mid-sequence checkpoint but
 is pure overhead for the common case: appending tokens to the end (turn_closure).
 
+> **Atomicity note:** this section decomposes a unit into `text_kv`, `backend_kv` and the
+> state image in order to reason about *what each part is for*. It does NOT license
+> storing, evicting or restoring them separately. Per the standing plan above, the
+> attention KV and the GDN state image are retained and restored as one unit.
+> `backend_kv` is a question about the unit's *internal composition* (whether GDN replay
+> records belong in it for the common forward-generation case) — not a proposal to split
+> state from KV.
+
 ### Three optimization levels
 
 **Level 1 — Drop backend_kv from host spill (keep text_kv + state image):**
+
+> **Compatible with the standing plan — not superseded.** This level keeps `text_kv`
+> (the attention KV) together with the state image, so the retained unit stays atomic. It
+> drops only `backend_kv`, the optional GDN replay records, which the atomicity note above
+> treats as the unit's internal composition rather than as a half of the unit. If this is
+> implemented, the added flag must be named for the dropped replay data (not for a partial
+> unit), and `is_complete_unit()` must continue to accept units without `backend_kv`.
 
 - Arena storage per checkpoint: ~6GB (text only) + ~150MB (state) = ~6.2GB
 - vs current ~12.5GB → **2x more checkpoints fit in the same arena**
@@ -344,6 +478,13 @@ is pure overhead for the common case: appending tokens to the end (turn_closure)
 
 **Level 2 — Drop both text_kv and backend_kv (state image only):**
 
+> **SUPERSEDED by the standing plan (atomic {KV + state} unit).** This level proposes
+> storing the state image WITHOUT its attention KV. Per the invariant that is not a
+> valid cache unit: the attention K/V for a position depends on the hidden state produced
+> by the preceding GDN layers, so it is not recomputable in isolation — the premise here
+> that only the attention layers need re-prefilling must be re-derived before this level
+> can be considered. Do not implement this level as written.
+
 - This is what state-only fallback already does!
 - ~150MB per checkpoint → effectively unlimited checkpoints in arena
 - Turn_closure: restore state image + re-prefill 7 attention layers only
@@ -353,6 +494,13 @@ is pure overhead for the common case: appending tokens to the end (turn_closure)
   a failure mode rather than a deliberate storage strategy
 
 **Level 3 — Don't store text_kv on device either (radical):**
+
+> **SUPERSEDED by the standing plan (atomic {KV + state} unit).** This level proposes
+> storing the state image WITHOUT its attention KV. Per the invariant that is not a
+> valid cache unit: the attention K/V for a position depends on the hidden state produced
+> by the preceding GDN layers, so it is not recomputable in isolation — the premise here
+> that only the attention layers need re-prefilling must be re-derived before this level
+> can be considered. Do not implement this level as written.
 
 - Device KV only holds 7 attention layers' worth of K/V (not 28 layers' text+backend)
 - Same 12.8GB device KV budget → **4x larger context** (555k → ~2.2M tokens)
@@ -496,6 +644,27 @@ disappear for typical workloads.
 
 ## Post-Thinking Sampler — Dynamic Sampling Parameter Switching
 
+> **Status: shipped** (`dd5534a5`). The preset, the CLI flags, the HTTP `post_thinking` object, the
+> per-phase fallback and the `--greedy` interaction below all landed as designed.
+>
+> **Measured outcome (2026-09-12)**, Qwen3.8-27B QUASAR NVFP4 with the thinking phase frozen at 1.0;
+> see [the post-thinking temperature study](docs/maintainer/post-thinking-temperature.md):
+>
+> - the premise below - that a lower answer-phase temperature substantially reduces errors in answers
+>   and tool calls - **did not reproduce on this stack**: no measurable accuracy or format effect on
+>   BFCL v4 tool calling (1240 paired samples, exact McNemar p = 0.79), AIME (60 problems per arm) or
+>   IFBench (300 samples per arm);
+> - the measurable effect is **reproducibility**: at identical numerical-route variation, long
+>   free-form answers became markedly more repeatable at the cold emission (100% to 62.5% distinct),
+>   while short structured output is insensitive at any temperature;
+> - the registered value is therefore a **reliability** setting rather than a quality one, and the
+>   study recommends reviewing the default - mirroring the thinking sampler, with 0.2 as an explicit
+>   opt-in;
+> - ReSET-style entropy-gated temperature is **deferred** for this setup: the symbolic damage pool it
+>   targets is not observable here, and this artifact is already quantization-aware trained.
+>
+> The design below is retained as written; only its premise is qualified by measurement.
+
 > **Attribution:** Based on [vLLM PR #52876](https://github.com/vllm-project/vllm/pull/52876),
 > which proposes separate post-thinking sampling parameters for reasoning models.
 
@@ -606,3 +775,122 @@ Still open:
 - The template knobs the frontend does not expose (`tool_call_format`,
   `auto_disable_thinking_with_tools`, `max_tool_arg_chars`, `max_tool_response_chars`)
   remain covered by the raw engine suite only.
+
+
+> **Reconciled with the standing plan:** the strip-invariance result below concerns the
+> GDN recurrent state, which is position-independent — that part stands. It does NOT
+> license storing the state WITHOUT its attention KV: "arena stores state image only" is
+> not a valid cache unit. A strip-thinking design must retain the attention KV and the
+> GDN state together; what may legitimately change is which *positions* the retained KV
+> covers, not whether the KV is kept.
+
+## Strip-Thinking-Cache — Don't Cache Reasoning KV (from vLLM/SGLang)
+
+> **Attribution:** Based on [vLLM PR #39806](https://github.com/vllm-project/vllm/pull/39806)
+> and [SGLang PR #23315](https://github.com/sgl-project/sglang/pull/23315).
+> Both identified the same problem and implemented the same solution independently.
+
+### The RoPE Position Problem
+
+When a client strips reasoning blocks from subsequent turns (the standard
+convention per DeepSeek/OpenAI API docs), the prefix cache breaks for a
+fundamental reason: **RoPE position shift**.
+
+Answer tokens after thinking have RoPE positional encodings computed at:
+```
+positions [input_len + thinking_len, input_len + thinking_len + answer_len]
+```
+
+In the next turn (without thinking), those same answer tokens appear at:
+```
+positions [input_len, input_len + answer_len]
+```
+
+The positions don't match. RoPE encodings are baked into the attention KV
+cache. The answer KV is **permanently invalid** after stripping thinking —
+not just a prefix-match failure, but a numerical correctness issue.
+
+This applies to YaRN-scaled positions too: YaRN is a scaling factor on
+RoPE positions. The shift is proportional. The problem exists with or
+without YaRN; YaRN doesn't make it better or worse.
+
+### What vLLM and SGLang Do
+
+Both engines added an opt-in flag (vLLM: `cache_reasoning_tokens=False`,
+SGLang: `--strip-thinking-cache`). On request completion with reasoning
+tokens detected:
+
+1. **Prompt prefix blocks** → normal cache path (retain hash for prefix matching)
+2. **Thinking + answer blocks** → immediately evicted (hash removed, blocks freed)
+
+Answer tokens are also stripped because their RoPE positions are mismatched.
+Both engines measured significant improvements:
+- SGLang: +6% cache hit rate, -1s TTFT (QwQ-32B, 2×B300)
+- vLLM: eliminates 1.3–1.6 GB dead branches per turn
+
+### ninfer's Advantage: Hybrid Architecture
+
+The RoPE position problem only affects the **7 attention layers** (25% of
+the model). The **21 GDN/SSM layers** (75%) don't use RoPE at all —
+confirmed in `gdn_mix()` which has no position/RoPE parameters. GDN uses
+`conv1d` + `gated_delta_net` (SSM recurrence), both position-independent.
+
+This means:
+- **Attention KV (text_kv, 7 layers):** NOT reusable after stripping thinking
+  (RoPE position shift). Must re-prefill.
+- **GDN recurrent state (state image, 21 layers):** Fully reusable regardless
+  of thinking token stripping or YaRN. The recurrent state captures all
+  history in a fixed-size tensor.
+
+### Proposed Implementation
+
+Add `--strip-thinking-cache` CLI flag (opt-in, default off).
+
+When enabled, on request completion with reasoning tokens detected:
+
+1. **Spill to host KV:** Only spill text_kv for the prompt prefix (before any
+   thinking block). Don't spill thinking + answer text_kv (RoPE-invalid).
+   Don't spill backend_kv (GDN replay records — not needed for forward gen,
+   and GDN state is in the state image).
+
+2. **State image:** Always preserve (GDN recurrent state is position-independent
+   and fully reusable).
+
+3. **Device KV:** Free thinking + answer KV pages immediately for reuse
+   (same as vLLM/SGLang immediate eviction).
+
+4. **Next turn restore:** Restore GDN state from state image (instant) +
+   re-prefill 7 attention layers for the prompt prefix + answer + new message.
+   Re-prefill cost: 25% of full model (7/28 layers).
+
+### Impact
+
+| Scenario | Without strip | With strip |
+|---|---|---|
+| Normal turn (no cancellation) | turn_closure (0.3s) | Re-prefill 7 layers (~25% compute) |
+| Cancellation turn (reasoning stripped) | Root prefill ALL 28 layers (124s) | Re-prefill 7 layers only (~31s) |
+| Arena storage per checkpoint | ~12.5GB (text+backend) | ~0.15GB (state image only) |
+| Arena capacity (30GB) | ~2.4 entries | ~200 entries |
+
+The trade-off: normal turns become slightly slower (re-prefill 7 layers
+instead of instant turn_closure), but cancellation turns become 4x faster
+(31s instead of 124s), and arena pressure drops by 80x.
+
+For interactive coding sessions where cancellation is common, this is a
+net win. For batch/streaming sessions without cancellation, the default
+(off) preserves the current fast turn_closure behavior.
+
+### Combined with Reasoning Block Shedding
+
+The `--strip-thinking-cache` flag and the reasoning block shedding plan
+are complementary:
+
+- **strip-thinking-cache:** Don't cache thinking+answer KV at all. Handle
+  the client-stripping case (cancellation). Arena stores state image only.
+- **Reasoning block shedding:** Keep thinking in the prompt (preserve_thinking=on),
+  tag and shed old reasoning KV in the engine. Handle the accumulation case.
+  Arena stores text_kv for responses only.
+
+Both reduce arena pressure. Both exploit the GDN/SSM advantage (75% of
+layers unaffected by RoPE position shift). They can be used together or
+independently depending on the workload.

--- a/src/runtime/contract/sampling.cpp
+++ b/src/runtime/contract/sampling.cpp
@@ -35,8 +35,8 @@ void validate(const ResolvedSamplingParameters& sampling) {
 } // namespace
 
 ResolvedSamplingParameters resolve_sampling(const ModelSamplingDefaults& defaults,
-                                            SamplingMode mode, const SamplingOverrides& overrides) {
-    const SamplingPreset& preset = defaults.for_mode(mode);
+                                            SamplingPhase phase, const SamplingOverrides& overrides) {
+    const SamplingPreset& preset = defaults.for_phase(phase);
     ResolvedSamplingParameters resolved{
         .temperature       = overrides.temperature.value_or(preset.temperature),
         .top_k             = overrides.top_k.value_or(preset.top_k),

--- a/src/runtime/contract/sampling.h
+++ b/src/runtime/contract/sampling.h
@@ -4,10 +4,11 @@
 
 namespace ninfer::runtime {
 
-// Resolves one request at the Engine boundary. The registered preset supplies every omitted
-// model-owned field; an omitted seed remains deterministic for direct Engine callers.
+// Resolves one request at the Engine boundary. The registered preset for the given phase
+// supplies every omitted model-owned field; an omitted seed remains deterministic for direct
+// Engine callers.
 [[nodiscard]] ResolvedSamplingParameters resolve_sampling(const ModelSamplingDefaults& defaults,
-                                                          SamplingMode mode,
+                                                          SamplingPhase phase,
                                                           const SamplingOverrides& overrides);
 
 } // namespace ninfer::runtime

--- a/src/runtime/contract/types.h
+++ b/src/runtime/contract/types.h
@@ -157,6 +157,10 @@ private:
 // and validated these values before constructing the runtime request.
 struct ResolvedExecutionOptions {
     ResolvedSamplingParameters sampling;
+    // Resolved at submit time; applied when the model closes its reasoning block.
+    ResolvedSamplingParameters post_thinking_sampling;
+    // Thinking is enabled and the model registered a real post-thinking preset.
+    bool post_thinking_configured = false;
     std::uint32_t requested_output_tokens = 0;
     bool allow_prefix_reuse               = true;
     ThinkingControlOptions thinking;

--- a/src/runtime/engine/engine.cpp
+++ b/src/runtime/engine/engine.cpp
@@ -93,8 +93,14 @@ runtime::ResolvedRequestOptions resolve_request_options(const ModelSamplingDefau
         throw std::invalid_argument("thinking budget must be positive");
     }
     runtime::ResolvedRequestOptions resolved;
+    const SamplingPhase initial_phase = initial_sampling_phase(mode);
     resolved.execution.sampling =
-        runtime::resolve_sampling(defaults, mode, options.execution.sampling);
+        runtime::resolve_sampling(defaults, initial_phase, options.execution.sampling);
+    if (mode == SamplingMode::Thinking && defaults.has_post_thinking) {
+        resolved.execution.post_thinking_sampling = runtime::resolve_sampling(
+            defaults, SamplingPhase::PostThinking, options.execution.post_thinking_sampling);
+        resolved.execution.post_thinking_configured = true;
+    }
     resolved.execution.requested_output_tokens = options.execution.requested_output_tokens;
     resolved.execution.allow_prefix_reuse      = options.execution.allow_prefix_reuse;
     resolved.execution.thinking                = options.execution.thinking;

--- a/src/runtime/engine/engine_core.h
+++ b/src/runtime/engine/engine_core.h
@@ -1166,6 +1166,14 @@ private:
                 auto published = request->output.commit_preview();
                 if (!request->first_token && accepted != 0) { request->first_token = Clock::now(); }
                 append_output(request, std::move(published));
+                if (decode_round && !cancelled[row] && !decisions[row].terminal &&
+                    request->options.execution.post_thinking_configured &&
+                    !request->post_thinking_applied && request->sequence &&
+                    request->output.reasoning_closed()) {
+                    instance_.program->update_sampling(*request->sequence,
+                                                       request->options.execution.post_thinking_sampling);
+                    request->post_thinking_applied = true;
+                }
                 if (decisions[row].terminal) {
                     if (cancelled[row]) {
                         terminal_requests[terminal_count] = request;

--- a/src/runtime/engine/request_record.h
+++ b/src/runtime/engine/request_record.h
@@ -172,6 +172,8 @@ struct RequestRecord {
     std::atomic<bool> cancelled{false};
     EngineRequestState model_state        = EngineRequestState::Waiting;
     bool capture_pending                  = false;
+    // Thinking -> post-thinking phase switch has been applied to this request's sampling.
+    bool post_thinking_applied            = false;
     EngineRequestState post_capture_state = EngineRequestState::Prefill;
     std::optional<FinishReason> terminal_reason;
 

--- a/src/serve/anthropic_messages_request.cpp
+++ b/src/serve/anthropic_messages_request.cpp
@@ -943,6 +943,26 @@ void parse_generation_fields(const Json& body, GenerationRequest& request) {
     if (request.sampling.top_k && (*request.sampling.top_k < 0 || *request.sampling.top_k > 20)) {
         bad_request("top_k must be in [0,20]", "top_k");
     }
+
+    if (body.contains("post_thinking") && !body.at("post_thinking").is_null()) {
+        if (!body.at("post_thinking").is_object()) {
+            bad_request("post_thinking must be an object", "post_thinking");
+        }
+        const Json& pt = body.at("post_thinking");
+        SamplingParams& out = request.post_thinking;
+        out.temperature     = optional_number(pt, "temperature");
+        out.top_p           = optional_number(pt, "top_p");
+        out.top_k           = optional_int(pt, "top_k");
+        if (out.temperature && (*out.temperature < 0.0 || *out.temperature > 2.0)) {
+            bad_request("post_thinking temperature must be in [0,2]", "post_thinking");
+        }
+        if (out.top_p && (*out.top_p < 0.0 || *out.top_p > 1.0)) {
+            bad_request("post_thinking top_p must be in [0,1]", "post_thinking");
+        }
+        if (out.top_k && (*out.top_k < 0 || *out.top_k > 20)) {
+            bad_request("post_thinking top_k must be in [0,20]", "post_thinking");
+        }
+    }
 }
 
 std::string parse_model(const Json& body) {

--- a/src/serve/openai_chat_request.cpp
+++ b/src/serve/openai_chat_request.cpp
@@ -785,6 +785,19 @@ void parse_sampling(const Json& body, GenerationRequest& output) {
     sampling.top_k = optional_int(body, "top_k");
     sampling.min_p = get_number(body, "min_p");
 
+    if (body.contains("post_thinking") && !body.at("post_thinking").is_null()) {
+        require_object(body.at("post_thinking"), "post_thinking must be an object", "post_thinking");
+        const Json& pt = body.at("post_thinking");
+        SamplingParams& out = output.post_thinking;
+        out.temperature       = get_number(pt, "temperature");
+        out.top_p             = get_number(pt, "top_p");
+        out.presence_penalty  = get_number(pt, "presence_penalty");
+        out.frequency_penalty = get_number(pt, "frequency_penalty");
+        out.seed              = get_seed(pt);
+        out.top_k             = optional_int(pt, "top_k");
+        out.min_p             = get_number(pt, "min_p");
+    }
+
     if (const std::optional<int> count = optional_int(body, "n")) {
         if (*count != 1) {
             bad_request("n requests multiple completions, while NInfer produces one completion per "

--- a/src/serve/openai_responses_request.cpp
+++ b/src/serve/openai_responses_request.cpp
@@ -1114,6 +1114,7 @@ void validate_common_top_level(const Json& body, bool create) {
                                                                   "model",
                                                                   "moderation",
                                                                   "parallel_tool_calls",
+                                                                  "post_thinking",
                                                                   "previous_response_id",
                                                                   "preserve_thinking",
                                                                   "prompt",
@@ -1250,6 +1251,62 @@ OpenAIResponsesCreateRequest parse_openai_responses_create_request(const Json& b
     if (const std::optional<double> top_p = optional_number(body, "top_p")) {
         if (*top_p < 0.0 || *top_p > 1.0) { bad_request("top_p must be in [0,1]", "top_p"); }
         out.prompt.generation.sampling.top_p = *top_p;
+    }
+    if (body.contains("post_thinking") && !body.at("post_thinking").is_null()) {
+        require_object(body.at("post_thinking"), "post_thinking");
+        const Json& pt = body.at("post_thinking");
+        SamplingParams& out_pt = out.prompt.generation.post_thinking;
+        if (const std::optional<double> temperature = optional_number(pt, "temperature")) {
+            if (*temperature < 0.0 || *temperature > 2.0) {
+                bad_request("post_thinking temperature must be in [0,2]", "post_thinking");
+            }
+            out_pt.temperature = *temperature;
+        }
+        if (const std::optional<double> pt_top_p = optional_number(pt, "top_p")) {
+            if (*pt_top_p < 0.0 || *pt_top_p > 1.0) {
+                bad_request("post_thinking top_p must be in [0,1]", "post_thinking");
+            }
+            out_pt.top_p = *pt_top_p;
+        }
+        if (const std::optional<int> pt_top_k = optional_int(pt, "top_k")) {
+            if (*pt_top_k < 0 || *pt_top_k > 20) {
+                bad_request("post_thinking top_k must be in [0,20]", "post_thinking");
+            }
+            out_pt.top_k = *pt_top_k;
+        }
+        if (const std::optional<double> pt_min_p = optional_number(pt, "min_p")) {
+            if (*pt_min_p < 0.0 || *pt_min_p > 1.0) {
+                bad_request("post_thinking min_p must be in [0,1]", "post_thinking");
+            }
+            out_pt.min_p = *pt_min_p;
+        }
+        if (const std::optional<double> pt_presence = optional_number(pt, "presence_penalty")) {
+            if (*pt_presence < -2.0 || *pt_presence > 2.0) {
+                bad_request("post_thinking presence_penalty must be in [-2,2]", "post_thinking");
+            }
+            out_pt.presence_penalty = *pt_presence;
+        }
+        if (const std::optional<double> pt_frequency = optional_number(pt, "frequency_penalty")) {
+            if (*pt_frequency < -2.0 || *pt_frequency > 2.0) {
+                bad_request("post_thinking frequency_penalty must be in [-2,2]", "post_thinking");
+            }
+            out_pt.frequency_penalty = *pt_frequency;
+        }
+        if (pt.contains("seed") && !pt.at("seed").is_null()) {
+            const Json& seed = pt.at("seed");
+            if (!seed.is_number_integer()) {
+                bad_request("post_thinking seed must be an integer", "post_thinking");
+            }
+            if (seed.is_number_unsigned()) {
+                out_pt.seed = seed.get<std::uint64_t>();
+            } else {
+                const std::int64_t value = seed.get<std::int64_t>();
+                if (value < 0) {
+                    bad_request("post_thinking seed must be non-negative", "post_thinking");
+                }
+                out_pt.seed = static_cast<std::uint64_t>(value);
+            }
+        }
     }
     if (const std::optional<int> max_output = optional_int(body, "max_output_tokens")) {
         if (*max_output < 0) {

--- a/src/serve/request.h
+++ b/src/serve/request.h
@@ -186,6 +186,9 @@ struct GenerationRequest {
     ninfer::PromptContinuationMode continuation = ninfer::PromptContinuationMode::NewAssistantTurn;
     bool allow_engine_automatic_shared_prefixes = true;
     SamplingParams sampling;
+    // Overrides applied from the token after the model closes its reasoning block. Omitted
+    // fields fall back to the model's post-thinking preset.
+    SamplingParams post_thinking;
 
     [[nodiscard]] bool uses_tools() const noexcept {
         return !tools.empty() && tool_choice.mode != ToolChoiceMode::None;

--- a/src/serve/translate.cpp
+++ b/src/serve/translate.cpp
@@ -86,6 +86,54 @@ ninfer::SamplingOverrides resolve_sampling_overrides(const SamplingParams& reque
     return sampling;
 }
 
+// Post-thinking overrides have no server default: only the request's own fields apply, and
+// omitted fields fall back to the model's post-thinking preset at the Engine boundary.
+ninfer::SamplingOverrides resolve_post_thinking_overrides(const SamplingParams& request,
+                                                          const ServeOptions& server) {
+    ninfer::SamplingOverrides sampling;
+    if (request.temperature) { sampling.temperature = static_cast<float>(*request.temperature); }
+    if (request.top_p) { sampling.top_p = static_cast<float>(*request.top_p); }
+    if (request.min_p) { sampling.min_p = static_cast<float>(*request.min_p); }
+    if (request.top_k) { sampling.top_k = static_cast<std::int32_t>(*request.top_k); }
+    if (request.presence_penalty) {
+        sampling.presence_penalty = static_cast<float>(*request.presence_penalty);
+    }
+    if (request.frequency_penalty) {
+        sampling.frequency_penalty = static_cast<float>(*request.frequency_penalty);
+    }
+    if (request.seed) { sampling.seed = *request.seed; }
+
+    const auto finite = [](const std::optional<float>& value) {
+        return !value || std::isfinite(*value);
+    };
+    if (!finite(sampling.temperature) || !finite(sampling.top_p) || !finite(sampling.min_p) ||
+        !finite(sampling.presence_penalty) || !finite(sampling.frequency_penalty)) {
+        invalid_sampling("post-thinking sampling parameters must be finite", "post_thinking");
+    }
+    if (sampling.temperature && (*sampling.temperature < 0.0F || *sampling.temperature > 2.0F)) {
+        invalid_sampling("post-thinking temperature must be in [0,2]", "post_thinking");
+    }
+    if (sampling.top_p && (*sampling.top_p < 0.0F || *sampling.top_p > 1.0F)) {
+        invalid_sampling("post-thinking top_p must be in [0,1]", "post_thinking");
+    }
+    if (sampling.top_k && (*sampling.top_k < 0 || *sampling.top_k > 20)) {
+        invalid_sampling("post-thinking top_k must be in [0,20]", "post_thinking");
+    }
+    if (sampling.min_p && (*sampling.min_p < 0.0F || *sampling.min_p > 1.0F)) {
+        invalid_sampling("post-thinking min_p must be in [0,1]", "post_thinking");
+    }
+    if (sampling.presence_penalty &&
+        (*sampling.presence_penalty < -2.0F || *sampling.presence_penalty > 2.0F)) {
+        invalid_sampling("post-thinking presence_penalty must be in [-2,2]", "post_thinking");
+    }
+    if (sampling.frequency_penalty &&
+        (*sampling.frequency_penalty < -2.0F || *sampling.frequency_penalty > 2.0F)) {
+        invalid_sampling("post-thinking frequency_penalty must be in [-2,2]", "post_thinking");
+    }
+    if (server.greedy) { sampling.temperature = 0.0F; }
+    return sampling;
+}
+
 std::vector<const ToolDefinition*> effective_tools(const GenerationRequest& request) {
     std::vector<const ToolDefinition*> tools;
     if (!request.uses_tools()) { return tools; }
@@ -307,6 +355,13 @@ ninfer::RequestOptions to_request_options(const GenerationRequest& request,
             request.thinking_budget ? request.thinking_budget : server.default_thinking_budget;
     }
     options.execution.sampling             = resolve_sampling_overrides(request.sampling, server);
+    // An explicit post-thinking seed wins; otherwise the request's resolved seed carries over so
+    // both phases share one random stream.
+    options.execution.post_thinking_sampling =
+        resolve_post_thinking_overrides(request.post_thinking, server);
+    if (!options.execution.post_thinking_sampling.seed) {
+        options.execution.post_thinking_sampling.seed = options.execution.sampling.seed;
+    }
     options.output.raw                     = false;
     options.output.preserve_special_tokens = request.uses_tools() || request.has_tool_history();
     options.output.tool_name_max_length = static_cast<std::uint32_t>(request.tool_name_max_length);

--- a/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/frontend.h
+++ b/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/frontend.h
@@ -112,6 +112,8 @@ public:
     [[nodiscard]] PublishedOutput commit_preview();
     [[nodiscard]] std::vector<GeneratedToolCall> take_tool_calls() noexcept;
     [[nodiscard]] std::uint32_t reasoning_tokens() const noexcept;
+    // True once the reasoning block has closed for a session that started in reasoning.
+    [[nodiscard]] bool reasoning_closed() const noexcept;
     [[nodiscard]] ThinkingBudgetStats thinking_stats() const noexcept;
     [[nodiscard]] std::optional<std::string> matched_stop_string() const;
 

--- a/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/runtime.h
+++ b/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/runtime.h
@@ -779,6 +779,10 @@ public:
     append_forced_tokens(std::span<const SequenceHandle<Variant>> sequences,
                          std::span<const TokenId> row_major_tokens, std::uint32_t row_stride,
                          runtime::ExecutionTiming* failed_timing = nullptr);
+    // Replace the device-lane sampling config mid-generation (thinking -> post-thinking phase
+    // switch). Takes effect from the next decode round.
+    void update_sampling(SequenceHandle<Variant> sequence,
+                         const runtime::ResolvedSamplingParameters& sampling);
     [[nodiscard]] CommitResult<Variant>
     commit(PendingBatch<Variant>&& pending, std::span<const runtime::CommitDecision> decisions,
            runtime::CommitObservation observation  = runtime::CommitObservation::AllRows,

--- a/src/targets/qwen3_6/impl/frontend/frontend.cpp
+++ b/src/targets/qwen3_6/impl/frontend/frontend.cpp
@@ -1269,6 +1269,10 @@ std::uint32_t OutputSession::reasoning_tokens() const noexcept {
     return impl_ != nullptr ? impl_->state.reasoning_tokens : 0;
 }
 
+bool OutputSession::reasoning_closed() const noexcept {
+    return impl_ != nullptr && impl_->split_reasoning && !impl_->state.in_reasoning;
+}
+
 ThinkingBudgetStats OutputSession::thinking_stats() const noexcept {
     if (impl_ == nullptr) { return {}; }
     return ThinkingBudgetStats{

--- a/src/targets/qwen3_6/impl/runtime/api_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/api_impl.h
@@ -434,6 +434,12 @@ runtime::ExecutionTiming Program<Variant>::append_forced_tokens(
 }
 
 template <>
+void Program<Variant>::update_sampling(SequenceHandle<Variant> sequence,
+                                       const runtime::ResolvedSamplingParameters& sampling) {
+    impl_->update_sampling(sequence, sampling);
+}
+
+template <>
 CommitResult<Variant> Program<Variant>::commit(PendingBatch<Variant>&& pending,
                                                std::span<const runtime::CommitDecision> decisions,
                                                runtime::CommitObservation observation,

--- a/src/targets/qwen3_6/impl/runtime/host_kv_safety_net.h
+++ b/src/targets/qwen3_6/impl/runtime/host_kv_safety_net.h
@@ -122,16 +122,7 @@ struct HostKVSafetyNetEntry {
 
     bool pinned = false;
 
-    // State-only entry: created by demotion (not eviction). Contains
-    // checkpoint state bytes but NO KV allocations (KV stays on device
-    // in the catalogued continuation). The restore path H2D copies only
-    // the state, not KV.
-    bool state_only = false;
 
-    // Continuation index that created this state-only entry. Used by
-    // the spill to match state-only entries to the continuation being
-    // evicted (for sessions without a session_key, e.g. OpenAI API).
-    std::uint32_t source_continuation_index = 0;
 
     // Unique ID for stable reference across vector modifications.
 
@@ -265,10 +256,6 @@ public:
 
             const HostKVSafetyNetEntry& entry = entries_[index];
 
-            // Skip state-only entries: they have no KV and cannot serve
-            // a full root materialization restore. They are only found
-            // via take_state_only() (direct lookup by session_key).
-            if (entry.state_only) { continue; }
 
             {
 
@@ -484,14 +471,104 @@ public:
 
     // restore) already owns its arena allocation, so no eviction is needed.
 
+    // --- Host state pool -------------------------------------------------
+    // Retained state images are host memory, exactly like host KV pages, so
+    // they share one accounted budget instead of living in unaccounted heap.
+    // The budget is set by the engine from the host memory budget.
+    void set_state_budget_bytes(std::size_t bytes) noexcept { state_budget_bytes_ = bytes; }
+    [[nodiscard]] std::size_t state_budget_bytes() const noexcept { return state_budget_bytes_; }
+    [[nodiscard]] std::size_t retained_state_bytes() const noexcept { return state_retained_bytes_; }
+
+    // Host KV pages and retained state images share ONE host memory budget. The
+    // arena is the other tenant, so it is queried live instead of duplicating the
+    // limit: neither pool may consume the other's headroom.
+    void set_shared_arena(const HostKVArena* arena) noexcept { shared_arena_ = arena; }
+
+    [[nodiscard]] std::size_t shared_occupied_bytes() const noexcept {
+        return (shared_arena_ != nullptr ? shared_arena_->occupied_bytes() : 0) +
+               state_retained_bytes_;
+    }
+
+    [[nodiscard]] static std::size_t entry_state_bytes(const HostKVSafetyNetEntry& entry) noexcept {
+        return entry.state_bytes + entry.checkpoint_state_bytes;
+    }
+
+    // A cache unit is {attention KV + GDN state}. It is retained atomically or not at
+    // all: KV without its state cannot resume (the attention K/V is not independently
+    // recomputable, because it depends on the GDN recurrence), and state without its KV
+    // is only usable while that KV is device-resident. A half unit is therefore refused
+    // rather than stored - it would waste host memory and, worse, prefix matching could
+    // select it and restore with a missing half, silently producing a wrong continuation.
+    [[nodiscard]] static bool is_complete_unit(const HostKVSafetyNetEntry& entry) noexcept {
+        const bool has_kv = entry.text_page_count != 0 || entry.backend_page_count != 0 ||
+                            !entry.text_allocations.empty() || !entry.backend_allocations.empty();
+        return has_kv && entry_state_bytes(entry) != 0;
+    }
+
+    // Re-prefill cost proxy for one unit. Cost scales with the retained context, so the
+    // retained KV page count is the comparable term; the state image is fixed size and
+    // common to every unit, so it cannot affect the ordering.
+    [[nodiscard]] static std::size_t unit_context_pages(const HostKVSafetyNetEntry& entry) noexcept {
+        return static_cast<std::size_t>(entry.text_page_count) +
+               static_cast<std::size_t>(entry.backend_page_count);
+    }
+
+    // Reclaim whole units until `incoming` fits the shared host budget. Eviction is
+    // cost-aware, NOT strict LRU: the smallest unit goes first, because re-prefilling a
+    // large context is far more expensive than re-prefilling a small one, and a large
+    // recent cache is worth keeping. Recency only breaks ties between units of
+    // comparable size. Returns false when the capture cannot be retained at all, so the
+    // caller degrades by not retaining instead of by growing host memory.
+    [[nodiscard]] bool retain_state_capture(std::size_t incoming) noexcept {
+        if (state_budget_bytes_ == 0) { return true; }
+        if (incoming > state_budget_bytes_) { return false; }
+        while (shared_occupied_bytes() + incoming > state_budget_bytes_) {
+            std::size_t victim      = entries_.size();
+            std::size_t victim_cost = 0;
+            for (std::size_t i = 0; i < entries_.size(); ++i) {
+                const HostKVSafetyNetEntry& candidate = entries_[i];
+                if (candidate.pinned || !is_complete_unit(candidate)) { continue; }
+                const std::size_t cost = unit_context_pages(candidate);
+                if (victim == entries_.size() || cost < victim_cost ||
+                    (cost == victim_cost && candidate.created < entries_[victim].created)) {
+                    victim      = i;
+                    victim_cost = cost;
+                }
+            }
+            if (victim == entries_.size()) { return false; }
+            std::fprintf(stderr,
+                         "[host-state-pool] evict=%zu ctx_pages=%zu state_bytes=%zu retained=%zu "
+                         "shared=%zu budget=%zu (smallest-unit-first)\n",
+                         victim, victim_cost, entry_state_bytes(entries_[victim]),
+                         state_retained_bytes_, shared_occupied_bytes(), state_budget_bytes_);
+            state_retained_bytes_ -= entry_state_bytes(entries_[victim]);
+            entries_.erase(entries_.begin() + static_cast<std::ptrdiff_t>(victim));
+        }
+        return true;
+    }
+
     void add(HostKVSafetyNetEntry entry) {
 
-        // State-only entries are bounded by the continuation count
-        // (at most one per continuation, enforced by remove_state_only_*
-        // cleanup at checkpoint creation and slot recycling).
-        // No artificial count limit — entries use heap memory which is
-        // naturally bounded by the number of active continuations.
+        // Atomicity first: KV and state are one unit, so a half unit is never stored.
+        if (!is_complete_unit(entry)) {
+            std::fprintf(stderr,
+                         "[safety-net] REJECT-PARTIAL state_bytes=%zu kv_pages=%u/%u - a cache unit "
+                         "is {KV + state}\n",
+                         entry_state_bytes(entry), entry.text_page_count, entry.backend_page_count);
+            return;
+        }
 
+        // Retention is bounded by the shared host memory budget. Completed continuations
+        // stay catalogued for prefix reuse, so units would otherwise accumulate once per
+        // conversation, each carrying a full state image in host memory.
+        const std::size_t incoming_state_bytes = entry_state_bytes(entry);
+        if (!retain_state_capture(incoming_state_bytes)) {
+            std::fprintf(stderr,
+                         "[host-state-pool] REJECT state_bytes=%zu retained=%zu budget=%zu\n",
+                         incoming_state_bytes, state_retained_bytes_, state_budget_bytes_);
+            return;
+        }
+        state_retained_bytes_ += incoming_state_bytes;
         entry.entry_id = ++next_entry_id_;
 
         entry.pinned = false;  // re-added entries are unpinned
@@ -500,108 +577,6 @@ public:
 
     }
 
-    // Find and remove a state-only entry matching the given session_key
-    // and checkpoint_frontier. Currently unused (reserved for future
-    // Step 5-6 work: start_sequence H2D restore from safety net).
-    [[nodiscard]] std::optional<HostKVSafetyNetEntry> take_state_only(
-        const qwen3_6::PreparedSessionKey& session_key,
-        std::uint32_t checkpoint_frontier) {
-        for (std::size_t i = 0; i < entries_.size(); ++i) {
-            HostKVSafetyNetEntry& entry = entries_[i];
-            if (!entry.state_only || !entry.checkpoint_valid ||
-                entry.checkpoint_frontier != checkpoint_frontier ||
-                !entry.session_key || !(*entry.session_key == session_key)) {
-                continue;
-            }
-            if (entry.checkpoint_state_bytes == 0 || entry.checkpoint_state_host.empty()) {
-                continue;
-            }
-            HostKVSafetyNetEntry result = std::move(entry);
-            entries_.erase(entries_.begin() + static_cast<std::ptrdiff_t>(i));
-            std::fprintf(stderr,
-                         "[safety-take-state-only] found entry: frontier=%u state_bytes=%zu\n",
-                         result.checkpoint_frontier, result.checkpoint_state_bytes);
-            return result;
-        }
-        std::fprintf(stderr,
-                     "[safety-take-state-only] NOT FOUND: frontier=%u\n",
-                     checkpoint_frontier);
-        return std::nullopt;
-    }
-
-    // Find and remove any state-only entry for a given session_key
-    // (regardless of checkpoint_frontier). Used during eviction when the
-    // continuation's rewrite_checkpoint was already cleared.
-    [[nodiscard]] std::optional<HostKVSafetyNetEntry> take_state_only_by_session(
-        const qwen3_6::PreparedSessionKey& session_key) {
-        for (std::size_t i = 0; i < entries_.size(); ++i) {
-            HostKVSafetyNetEntry& entry = entries_[i];
-            if (!entry.state_only || !entry.checkpoint_valid ||
-                !entry.session_key || !(*entry.session_key == session_key)) {
-                continue;
-            }
-            if (entry.checkpoint_state_bytes == 0 || entry.checkpoint_state_host.empty()) {
-                continue;
-            }
-            HostKVSafetyNetEntry result = std::move(entry);
-            entries_.erase(entries_.begin() + static_cast<std::ptrdiff_t>(i));
-            std::fprintf(stderr,
-                "[safety-take-state-only-by-session] found entry: frontier=%u state_bytes=%zu\n",
-                result.checkpoint_frontier, result.checkpoint_state_bytes);
-            return result;
-        }
-        return std::nullopt;
-    }
-
-    // Find and remove any state-only entry for a given continuation index.
-    // Used during eviction when the continuation has no session_key
-    // (e.g. OpenAI /v1/chat/completions API without session tracking).
-    [[nodiscard]] std::optional<HostKVSafetyNetEntry> take_state_only_by_index(
-        std::uint32_t continuation_index) {
-        for (std::size_t i = 0; i < entries_.size(); ++i) {
-            HostKVSafetyNetEntry& entry = entries_[i];
-            if (!entry.state_only || !entry.checkpoint_valid ||
-                entry.source_continuation_index != continuation_index) {
-                continue;
-            }
-            if (entry.checkpoint_state_bytes == 0 || entry.checkpoint_state_host.empty()) {
-                continue;
-            }
-            HostKVSafetyNetEntry result = std::move(entry);
-            entries_.erase(entries_.begin() + static_cast<std::ptrdiff_t>(i));
-            std::fprintf(stderr,
-                "[safety-take-state-only-by-index] found entry: idx=%u frontier=%u state_bytes=%zu\n",
-                continuation_index, result.checkpoint_frontier,
-                result.checkpoint_state_bytes);
-            return result;
-        }
-        return std::nullopt;
-    }
-
-    // Remove all state-only entries for a given session_key or index.
-    // Remove all state-only entries for a given session_key or index.
-    void remove_state_only(const qwen3_6::PreparedSessionKey& session_key) {
-        for (std::size_t i = 0; i < entries_.size(); ) {
-            if (entries_[i].state_only && entries_[i].session_key &&
-                *entries_[i].session_key == session_key) {
-                entries_.erase(entries_.begin() + static_cast<std::ptrdiff_t>(i));
-            } else {
-                ++i;
-            }
-        }
-    }
-
-    // Remove all state-only entries for a given continuation index.
-    void remove_state_only_by_index(std::uint32_t continuation_index) {
-        for (std::size_t i = 0; i < entries_.size(); ) {
-            if (entries_[i].state_only &&
-                entries_[i].source_continuation_index == continuation_index) {
-                entries_.erase(entries_.begin() + static_cast<std::ptrdiff_t>(i));
-            } else {
-                ++i;
-            }
-        }
-    }
 
 
 
@@ -617,6 +592,8 @@ public:
 
         HostKVSafetyNetEntry out = std::move(entries_[index]);
 
+        state_retained_bytes_ -= (entries_[index].state_bytes +
+                                         entries_[index].checkpoint_state_bytes);
         entries_.erase(entries_.begin() + static_cast<std::ptrdiff_t>(index));
 
         return out;
@@ -647,6 +624,8 @@ public:
 
         if (index >= entries_.size()) { return; }
 
+        state_retained_bytes_ -= (entries_[index].state_bytes +
+                                         entries_[index].checkpoint_state_bytes);
         entries_.erase(entries_.begin() + static_cast<std::ptrdiff_t>(index));
 
     }
@@ -699,6 +678,7 @@ public:
 
                 HostKVSafetyNetEntry out = std::move(*it);
 
+                state_retained_bytes_ -= (it->state_bytes + it->checkpoint_state_bytes);
                 entries_.erase(it);
 
                 return out;
@@ -717,7 +697,10 @@ public:
 
 
 
-    void clear() noexcept { entries_.clear(); }
+    void clear() noexcept {
+        entries_.clear();
+        state_retained_bytes_ = 0;
+    }
 
 
 
@@ -726,6 +709,11 @@ private:
     std::vector<HostKVSafetyNetEntry> entries_;
 
     std::uint64_t next_entry_id_ = 0;
+    // Retained state-image bytes and their budget (0 = unbounded).
+    std::size_t state_budget_bytes_    = 0;
+    std::size_t state_retained_bytes_  = 0;
+    // Live view of the other tenant of the shared host budget (KV pages).
+    const HostKVArena* shared_arena_ = nullptr;
 
 };
 

--- a/src/targets/qwen3_6/impl/runtime/program.h
+++ b/src/targets/qwen3_6/impl/runtime/program.h
@@ -631,6 +631,10 @@ public:
     append_forced_tokens(std::span<const SequenceHandle> sequences,
                          std::span<const TokenId> row_major_tokens, std::uint32_t row_stride,
                          runtime::ExecutionTiming* failed_timing);
+    // Replace the device-lane sampling config mid-generation (thinking -> post-thinking
+    // phase switch). Takes effect from the next decode round.
+    void update_sampling(SequenceHandle sequence,
+                         const runtime::ResolvedSamplingParameters& sampling);
     [[nodiscard]] CommitResult commit(PendingBatch&& pending,
                                       std::span<const runtime::CommitDecision> decisions,
                                       runtime::CommitObservation observation,
@@ -690,9 +694,9 @@ public:
     HostKVSafetyNet host_kv_safety_net;
     std::uint64_t safety_net_restore_count_ = 0;
 
-    // Checkpoint state captures go to the safety net as state-only entries
-    // (unified architecture). The old DroppedCheckpointCapture side store
-    // has been removed.
+    // Checkpoint state is retained only inside a complete {attention KV + GDN state}
+    // unit held by the safety net; there is no state-only capture. The old
+    // DroppedCheckpointCapture side store has been removed.
     std::size_t text_host_kv_page_stride    = 0;
     std::size_t backend_host_kv_page_stride = 0;
     std::unique_ptr<qwen3_6::StateImageDevicePool> state_images;

--- a/src/targets/qwen3_6/impl/runtime/program_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/program_impl.h
@@ -907,6 +907,13 @@ ProgramImplCore::ProgramImplCore(const LoadedModelData& model_in, const Sequence
         host_kv_arena = std::make_unique<HostKVArena>(
             plan.context_cache.host_kv_capacity_bytes,
             std::span<const HostKVPageLayout>(layouts.data(), layouts.size()));
+        // Retained state images are host memory exactly like host KV pages, so they
+        // are governed by an explicit byte budget instead of growing as heap. The
+        // budget matches the host KV capacity and the retained bytes are folded into
+        // the reported host occupancy below, so one number reflects the true host
+        // footprint of the context cache.
+        host_kv_safety_net.set_shared_arena(host_kv_arena.get());
+        host_kv_safety_net.set_state_budget_bytes(plan.context_cache.host_kv_capacity_bytes);
         std::size_t minimum_stride = layouts.front().page_stride;
         for (const HostKVPageLayout& layout : layouts) {
             minimum_stride = std::min(minimum_stride, layout.page_stride);
@@ -1806,12 +1813,10 @@ std::vector<qwen3_6::detail::PressureDecision> ProgramImplCore::inspect_pressure
     if (summary.endpoint) { append_checkpoint_successor(summary.endpoint->ref); }
     // Do NOT generate drop successors for rewrite checkpoints.
     // Principle: KV and checkpoint state move together to host, or not at all.
-    // Dropping a rewrite checkpoint (state only, keep KV on device) loses
-    // the checkpoint for the inspect — the follow-up must re-prefill.
-    // Instead, the pressure planner evicts the entire continuation
+    // Dropping a rewrite checkpoint while keeping its KV on device is refused by
+    // design: it would strand the state without its KV, which is not a restorable
+    // unit. Instead, the pressure planner evicts the entire continuation
     // (KV + state together to the safety net) when it needs the slot.
-    // The state-only safety net entry created at drop time (if any) is
-    // merged into the full entry by the spill function.
     // if (summary.rewrite) { append_checkpoint_successor(summary.rewrite->ref); }
     for (const qwen3_6::CheckpointSummary& anchor : summary.long_anchors) {
         append_checkpoint_successor(anchor.ref);
@@ -5422,86 +5427,15 @@ void ProgramImplCore::publish_pressure_host_releases(
         if (sequence == nullptr) {
             throw std::logic_error("checkpoint drop targets a shared pressure owner");
         }
-        bool capture_added_this_work = false;
         for (const runtime::CheckpointRef checkpoint : work.option.dropped_checkpoints) {
-            // Drop-time checkpoint capture: publish_checkpoint_drop releases the
-            // rewrite state image below; copy it to host first so a later
-            // session return can restore the checkpoint via H2D from the safety
-            // net. Device-resident images copy D2H; demoted (HostOnly) images
-            // copy host-to-host from the pool view.
-            //
-            // The captured state goes directly into a state-only
-            // HostKVSafetyNetEntry (not the old
-            // dropped_checkpoint_captures_ side store). The state-only
-            // entry is NOT findable by find() (it has no KV). It is
-            // merged into a full entry by the spill function when the
-            // continuation is later evicted. The continuation stays
-            // catalogued (KV on device) until eviction.
-            // Note: rewrite checkpoints (TurnClosure/ResponseReplay) are no
-            // longer dropped by the pressure planner (Step 3). This branch
-            // is currently unreachable but kept as defensive code in case
-            // rewrite drops are re-enabled in the future.
-            if ((checkpoint.kind == runtime::CheckpointKind::TurnClosure ||
-                 checkpoint.kind == runtime::CheckpointKind::ResponseReplay) &&
-                sequence->rewrite_state && state_store &&
-                state_store->valid(*sequence->rewrite_state) && state_images) {
-                const std::size_t capture_bytes = state_images->host_layout().image_bytes;
-                if (capture_bytes > 0) {
-                    std::vector<std::byte> state_host(capture_bytes);
-                    const StateReplicaResidency residency =
-                        state_store->residency(*sequence->rewrite_state);
-                    bool captured = false;
-                    if (residency == StateReplicaResidency::DeviceOnly ||
-                        residency == StateReplicaResidency::Both) {
-                        const std::int32_t slot =
-                            state_store->physical_slot(*sequence->rewrite_state);
-                        const HostStateImageView capture_view{
-                            .data = state_host.data(),
-                            .layout = &state_images->host_layout()};
-                        state_images->copy_to_host(slot, capture_view, device.transfer_stream);
-                        captured = true;
-                    } else if (const std::optional<qwen3_6::HostStateImageConstView> host_view =
-                                   state_store->host_replica_view(*sequence->rewrite_state);
-                               host_view && host_view->data != nullptr) {
-                        std::memcpy(state_host.data(), host_view->data, capture_bytes);
-                        captured = true;
-                    }
-                    if (captured) {
-                        // Create a state-only safety net entry. The continuation
-                        // stays catalogued (KV on device), so we COPY (not move)
-                        // the matching metadata. The safety-find will match by
-                        // checkpoint_frontier / session_key / compact_prefix.
-                        HostKVSafetyNetEntry entry;
-                        entry.state_only = true;
-                        entry.source_continuation_index = work.continuation_index;
-                        entry.checkpoint_valid = true;
-                        entry.checkpoint_frontier = checkpoint.frontier;
-                        entry.checkpoint_state_host = std::move(state_host);
-                        entry.checkpoint_state_bytes = capture_bytes;
-                        // Copy matching metadata — continuation still needs these.
-                        entry.session_key = sequence->session_key;
-                        entry.execution_frontier = 0;  // no KV spilled
-                        // Remove stale state-only entries before adding.
-                        host_kv_safety_net.remove_state_only_by_index(work.continuation_index);
-                        if (sequence->session_key) {
-                            host_kv_safety_net.remove_state_only(*sequence->session_key);
-                        }
-                        std::fprintf(stderr,
-                                     "[checkpoint-demoted] index=%u frontier=%u ckpt_frontier=%u "
-                                     "state_bytes=%zu\n",
-                                     work.continuation_index,
-                                     sequence->execution_frontier,
-                                     checkpoint.frontier, capture_bytes);
-                        host_kv_safety_net.add(std::move(entry));
-                        capture_added_this_work = true;
-                    }
-                }
-            }
+            // Checkpoint capture is no longer performed here. A cache unit is
+            // {attention KV + GDN state} and is retained whole by the spill path, which
+            // stores the continuation's attention KV together with its state image, or
+            // stores nothing at all. Capturing the state image alone - while the KV
+            // stayed on device - is what grew host memory without bound and is no longer
+            // permitted. If rewrite drops are ever re-enabled, the retention to add here
+            // is a complete-unit spill, not a state-only capture.
             publish_checkpoint_drop(*sequence, checkpoint);
-        }
-        if (capture_added_this_work) {
-            // Complete this work's capture D2H copies before the vectors are held.
-            CUDA_CHECK(cudaStreamSynchronize(device.transfer_stream));
         }
         delta.removed =
             checked_resource_sum(delta.removed, work.option.checkpoint_drop_effect.removed);
@@ -5863,9 +5797,10 @@ void ProgramImplCore::spill_victim_to_host_kv_safety_net(std::uint32_t index) no
             return;
         }
 
-        // Check if the arena has enough free capacity for text; if not, evict
-        // LRU safety-net entries until it fits (the old HostKvCache acquire_slab
-        // behavior — a new victim is worth more than the oldest parked one).
+        // Check if the arena has enough free capacity for text; if not, reclaim whole
+        // units until it fits. Reclaim is cost-aware, not LRU: the smallest unit goes
+        // first, because re-prefilling a large context is the most expensive, and a
+        // recently parked large cache is worth keeping. Recency breaks ties only.
         const std::size_t text_bytes = text_layout->page_stride * text_pages;
         const std::size_t needed_total = [&] {
             const HostKVPageLayout* bl =
@@ -5882,8 +5817,6 @@ void ProgramImplCore::spill_victim_to_host_kv_safety_net(std::uint32_t index) no
             std::size_t reclaimable = 0;
             const std::size_t per_page = text_bytes / std::max(1U, text_pages);
             for (std::size_t i = 0; i < host_kv_safety_net.size(); ++i) {
-                // State-only entries use heap, not arena — no reclaimable bytes.
-                if (host_kv_safety_net.at(i).state_only) { continue; }
                 reclaimable += per_page *
                     (host_kv_safety_net.at(i).text_page_count +
                      host_kv_safety_net.at(i).backend_page_count);
@@ -5891,7 +5824,8 @@ void ProgramImplCore::spill_victim_to_host_kv_safety_net(std::uint32_t index) no
             if (host_kv_arena->free_bytes() + reclaimable < needed_total) {
                 std::fprintf(stderr,
                              "[safety-spill] FAIL: insufficient capacity even after evicting all "
-                             "(free=%zu reclaimable=%zu need=%zu) — falling back to state-only\n",
+                             "(free=%zu reclaimable=%zu need=%zu) - no room for a complete unit, "
+                             "retaining nothing\n",
                              host_kv_arena->free_bytes(), reclaimable, needed_total);
                 kv_copy_ok = false;
             }
@@ -5914,9 +5848,6 @@ void ProgramImplCore::spill_victim_to_host_kv_safety_net(std::uint32_t index) no
             for (std::size_t i = 0; i < host_kv_safety_net.size(); ++i) {
                 // Phase 1: only evict unpinned. Phase 2: also evict pinned.
                 if (!pinned_eviction_started && host_kv_safety_net.at(i).pinned) { continue; }
-                // Skip state-only entries: they use heap memory, not arena
-                // memory. Evicting them frees no arena bytes.
-                if (host_kv_safety_net.at(i).state_only) { continue; }
                 const std::uint64_t pages = static_cast<std::uint64_t>(host_kv_safety_net.at(i).text_page_count)
                                           + host_kv_safety_net.at(i).backend_page_count;
                 if (!victim || pages < victim_pages ||
@@ -5958,7 +5889,9 @@ void ProgramImplCore::spill_victim_to_host_kv_safety_net(std::uint32_t index) no
             else {
                 backend_bytes = backend_layout->page_stride * backend_pages;
                 if (host_kv_arena->free_bytes() < text_bytes + backend_bytes) {
-                    std::fprintf(stderr, "[safety-spill] FAIL: backend capacity free=%zu need=%zu — state-only\n",
+                    std::fprintf(stderr,
+                                 "[safety-spill] FAIL: backend capacity free=%zu need=%zu - no room "
+                                 "for a complete unit, retaining nothing\n",
                                  host_kv_arena->free_bytes(), text_bytes + backend_bytes);
                     kv_copy_ok = false;
                 }
@@ -5992,7 +5925,7 @@ void ProgramImplCore::spill_victim_to_host_kv_safety_net(std::uint32_t index) no
         }
         // Copy D2H for text KV, iterating over allocations (scatter-gather).
         // If device pages are unavailable (device_replica cleared by a prior
-        // release_reference), skip the KV copy and fall back to state-only entry.
+        // release_reference), the unit cannot be completed and nothing is retained.
         kv_copy_ok = kv_copy_ok && !text_allocations.empty();
         std::fprintf(stderr,
                      "[safety-spill] D2H text: index=%u pages=%u allocations=%zu active=%d\n",
@@ -6033,8 +5966,8 @@ void ProgramImplCore::spill_victim_to_host_kv_safety_net(std::uint32_t index) no
                     // Some pages have neither device nor host replica.
                     try { cudaStreamSynchronize(device.transfer_stream); } catch (...) {}
                     std::fprintf(stderr,
-                                 "[safety-spill] KV_COPY_SKIP: index=%u — %u device + %u host / %u pages, "
-                                 "falling back to state-only entry\n",
+                                 "[safety-spill] KV_COPY_SKIP: index=%u - %u device + %u host / %u pages, "
+                                 "unit incomplete, retaining nothing\n",
                                  index, resident_pages, host_copy_pages, alloc_pages);
                     text_allocations.clear();
                     kv_copy_ok = false;
@@ -6063,7 +5996,7 @@ void ProgramImplCore::spill_victim_to_host_kv_safety_net(std::uint32_t index) no
             }
         }
         // Allocate host memory and copy D2H for backend KV if present.
-        // Skip when KV copy failed (state-only fallback).
+        // Skip when the KV copy failed: the unit is incomplete and is not retained.
         if (kv_copy_ok && backend_pages != 0) {
             std::fprintf(stderr,
                          "[safety-spill] D2H backend: index=%u pages=%u\n",
@@ -6126,7 +6059,8 @@ void ProgramImplCore::spill_victim_to_host_kv_safety_net(std::uint32_t index) no
                         alloc_device_pages, host_kv_arena->writable_view(alloc),
                         device.transfer_stream);
                 } else {
-                    // Pages missing — can't recover. Fall back to state-only.
+                    // Pages missing - not recoverable. The unit is incomplete, so nothing is
+                    // retained rather than storing a half unit.
                     try { cudaStreamSynchronize(device.transfer_stream); } catch (...) {}
                     text_allocations.clear();
                     backend_allocations.clear();
@@ -6213,29 +6147,10 @@ void ProgramImplCore::spill_victim_to_host_kv_safety_net(std::uint32_t index) no
             }
         }
 
-        // When the checkpoint was dropped (rewrite_checkpoint cleared),
-        // a state-only safety net entry was created at capture time with the
-        // checkpoint state. Merge it into this full entry so the safety
-        // net can serve checkpoint-level restores after eviction.
-        // Match by continuation index first (always available), then by
-        // session_key (for Responses API sessions).
-        if (!checkpoint_valid) {
-            auto sn_entry = host_kv_safety_net.take_state_only_by_index(index);
-            if (!sn_entry && sequence.session_key) {
-                sn_entry = host_kv_safety_net.take_state_only_by_session(
-                    *sequence.session_key);
-            }
-            if (sn_entry) {
-                checkpoint_valid = true;
-                checkpoint_frontier = sn_entry->checkpoint_frontier;
-                checkpoint_state_bytes = sn_entry->checkpoint_state_bytes;
-                checkpoint_state_host = std::move(sn_entry->checkpoint_state_host);
-                std::fprintf(stderr,
-                    "[safety-spill] merged dropped checkpoint state from state-only entry "
-                    "(frontier=%u bytes=%zu)\n",
-                    checkpoint_frontier, checkpoint_state_bytes);
-            }
-        }
+        // The checkpoint state is captured from the sequence's own rewrite state below.
+        // There is no state-only entry class to merge from: a unit is retained as
+        // {attention KV + GDN state} or not at all, so a checkpoint that was dropped
+        // without its KV is not a restorable unit.
 
         // Diagnostic: log WHY checkpoint capture failed, but only after all
         // capture hooks have been attempted.
@@ -6284,14 +6199,16 @@ void ProgramImplCore::spill_victim_to_host_kv_safety_net(std::uint32_t index) no
                          static_cast<unsigned long long>(cp_hash),
                          entry.execution_frontier, entry.checkpoint_frontier);
         }
-        // If KV copy was skipped (device pages unavailable), mark as state-only.
-        // The entry has checkpoint state but no KV — find() will skip it for
-        // full KV restore, but take_state_only_by_session/index can still
-        // merge it during a later spill that succeeds.
+        // Atomicity: a cache unit is {attention KV + GDN state}. If the KV could not be
+        // copied, this is not a cache unit. KV without its state cannot resume (the
+        // attention K/V is not independently recomputable), and state without its KV is
+        // only usable while that KV is device-resident. Retain nothing rather than half.
         if (text_allocations.empty()) {
-            entry.state_only = true;
-            entry.source_continuation_index = index;
-            entry.execution_frontier = 0;  // no KV spilled
+            std::fprintf(stderr,
+                         "[safety-spill] ABORT: index=%u frontier=%u — KV copy unavailable; "
+                         "KV and state are one atomic unit, nothing retained\n",
+                         index, sequence.execution_frontier);
+            return;
         }
         entry.text_page_count = text_allocations.empty() ? 0 : text_pages;
         entry.backend_page_count = backend_allocations.empty() ? 0 : backend_pages;
@@ -6307,20 +6224,15 @@ void ProgramImplCore::spill_victim_to_host_kv_safety_net(std::uint32_t index) no
         // endpoint state; if missing (state store evicted the endpoint),
         // fall back to the checkpoint state as the restore state.
         if (entry.state_bytes == 0 || entry.state_host.empty()) {
-            // Endpoint state missing — fall back to checkpoint state.
-            // For state-only entries (KV copy failed), keep checkpoint state
-            // as-is so take_state_only_by_index can still find it.
-            // For full entries, move checkpoint to endpoint (existing behavior).
-            if (!entry.state_only &&
-                entry.checkpoint_valid && entry.checkpoint_state_bytes > 0 &&
+            // Endpoint state missing — fall back to the checkpoint state so the unit
+            // still carries a state image (an entry without one is never retained).
+            if (entry.checkpoint_valid && entry.checkpoint_state_bytes > 0 &&
                 !entry.checkpoint_state_host.empty()) {
                 entry.state_bytes = entry.checkpoint_state_bytes;
                 entry.state_host = std::move(entry.checkpoint_state_host);
                 entry.checkpoint_valid = false;
                 entry.checkpoint_state_bytes = 0;
-                if (!entry.state_only) {
-                    entry.execution_frontier = checkpoint_frontier;
-                }
+                entry.execution_frontier = checkpoint_frontier;
                 std::fprintf(stderr,
                              "[safety-spill] FALLBACK: using checkpoint state as endpoint "
                              "(index=%u frontier=%u ckpt_frontier=%u)\n",
@@ -6333,7 +6245,12 @@ void ProgramImplCore::spill_victim_to_host_kv_safety_net(std::uint32_t index) no
             }
         }
         if (entry.state_bytes == 0 || entry.state_host.empty()) {
-            // Still no state after fallback — skip this entry.
+            // No state image after the fallback. {@code KV + state} is the unit, so an
+            // entry without its state is not a cache unit: retain nothing.
+            std::fprintf(stderr,
+                         "[safety-spill] ABORT: index=%u frontier=%u — no state image; "
+                         "KV and state are one atomic unit, nothing retained\n",
+                         index, sequence.execution_frontier);
         } else {
             std::fprintf(stderr,
                          "[safety-spill] OK: index=%u frontier=%u ckpt_valid=%d ckpt_frontier=%u "
@@ -7232,12 +7149,6 @@ void ProgramImplCore::release_continuation_slot(std::uint32_t index) noexcept {
     ContinuationSlot& slot = continuation_slots[index];
     slot.role              = ContinuationSlotRole::Free;
     if (++slot.generation == 0) { ++slot.generation; }
-    // Clean up any state-only safety net entries for this slot to
-    // prevent stale entries from matching a recycled slot.
-    host_kv_safety_net.remove_state_only_by_index(index);
-    if (continuation_states[index].session_key) {
-        host_kv_safety_net.remove_state_only(*continuation_states[index].session_key);
-    }
 }
 
 detail::PhysicalResources
@@ -9778,36 +9689,14 @@ FinishResult ProgramImplCore::finish(SequenceHandle sequence) noexcept {
                 if (capture_bytes > 0 &&
                     state_store->residency(state.state.read) != StateReplicaResidency::None &&
                     state_store->residency(state.state.read) != StateReplicaResidency::HostOnly) {
-                    // Unified architecture: create a state-only safety net entry
-                    // instead of using the dropped_checkpoint_captures_ side store.
-                    std::vector<std::byte> capture_host(capture_bytes);
-                    const std::int32_t slot_num = state_store->physical_slot(state.state.read);
-                    const HostStateImageView capture_view{
-                        .data = capture_host.data(),
-                        .layout = &state_images->host_layout()};
-                    state_images->copy_to_host(slot_num, capture_view, device.transfer_stream);
-                    CUDA_CHECK(cudaStreamSynchronize(device.transfer_stream));
-                    HostKVSafetyNetEntry sn_entry;
-                    sn_entry.state_only = true;
-                    sn_entry.source_continuation_index = continuation_index;
-                    sn_entry.checkpoint_valid = true;
-                    sn_entry.checkpoint_frontier = state.rewrite_checkpoint.frontier;
-                    sn_entry.checkpoint_state_host = std::move(capture_host);
-                    sn_entry.checkpoint_state_bytes = capture_bytes;
-                    sn_entry.session_key = state.session_key;
-                    sn_entry.execution_frontier = 0;
-                    // Remove stale state-only entries for this slot/session
-                    // before adding -- ensures at most one entry per session.
-                    host_kv_safety_net.remove_state_only_by_index(continuation_index);
-                    if (state.session_key) {
-                        host_kv_safety_net.remove_state_only(*state.session_key);
-                    }
+                    // A cache unit is {attention KV + GDN state}, retained whole or not at
+                    // all. Retaining this state image while its KV stays on device is not a
+                    // restorable unit, and it was the unbounded host-memory growth this fix
+                    // removes. Retention happens in the spill path, which stores a complete
+                    // unit or nothing.
                     std::fprintf(stderr,
-                        "[checkpoint-demoted] finish: index=%u frontier=%u ckpt_frontier=%u "
-                        "state_bytes=%zu\n",
-                        continuation_index, state.execution_frontier,
-                        state.rewrite_checkpoint.frontier, capture_bytes);
-                    host_kv_safety_net.add(std::move(sn_entry));
+                                 "[checkpoint] unit-not-retained: a cache unit is {KV + state}; "
+                                 "retention happens only through the spill path\n");
                 }
             }
             // Materialize a real rewrite checkpoint image. In the
@@ -9821,10 +9710,10 @@ FinishResult ProgramImplCore::finish(SequenceHandle sequence) noexcept {
             std::optional<StateImageHandle> new_rewrite = state_store->reserve_destination();
             if (!new_rewrite && state.rewrite_state && state_store && state_images &&
                 state_store->residency(*state.rewrite_state) == StateReplicaResidency::DeviceOnly) {
-                // No device slot for the new checkpoint. Capture the OLD
-                // checkpoint state to a host buffer (D2H), then release
-                // its device slot for the new checkpoint. The captured
-                // state goes into a state-only safety net entry.
+                // No device slot for the new checkpoint. Move the OLD checkpoint state to a
+                // host buffer (D2H) so its device slot can be reused for the new checkpoint.
+                // The buffered state is never retained on its own: it only exists inside a
+                // complete {KV + state} unit, which the spill path builds.
                 // Unified architecture — no host_state_images dependency.
                 std::fprintf(stderr,
                     "[checkpoint] demoting old checkpoint to host (frontier=%u)\n",
@@ -9868,107 +9757,24 @@ FinishResult ProgramImplCore::finish(SequenceHandle sequence) noexcept {
                     state_store->release_checkpoint_reference(*state.rewrite_state);
                 }
                 state.rewrite_state = *new_rewrite;
-                // Move the captured state to the safety net AFTER the
-                // H2D copy is complete (the buffer was needed for copy).
+                // No state-only capture happens here. A cache unit is {KV + state}: this
+                // path holds a state image while the continuation's attention KV is not
+                // part of the entry, so retaining the state alone is not a restorable unit,
+                // and it was the unbounded host-memory growth this change removes.
+                // Retention is the spill path's job, which stores a complete unit or
+                // nothing and performs its own D2H copy - so nothing is copied here.
                 if (demoted_from_host && !demoted_host_buffer.empty()) {
-                    host_kv_safety_net.remove_state_only_by_index(continuation_index);
-                    if (state.session_key) {
-                        host_kv_safety_net.remove_state_only(*state.session_key);
-                    }
-                    HostKVSafetyNetEntry sn_entry;
-                    sn_entry.state_only = true;
-                    sn_entry.source_continuation_index = continuation_index;
-                    sn_entry.checkpoint_valid = true;
-                    sn_entry.checkpoint_frontier = state.rewrite_checkpoint.frontier;
-                    sn_entry.checkpoint_state_host = std::move(demoted_host_buffer);
-                    sn_entry.checkpoint_state_bytes = state_images->host_layout().image_bytes;
-                    sn_entry.session_key = state.session_key;
-                    sn_entry.execution_frontier = 0;
                     std::fprintf(stderr,
-                        "[checkpoint-demoted] finish: index=%u frontier=%u ckpt_frontier=%u "
-                        "state_bytes=%zu\n",
-                        continuation_index, state.execution_frontier,
-                        state.rewrite_checkpoint.frontier,
-                        static_cast<std::size_t>(state_images->host_layout().image_bytes));
-                    host_kv_safety_net.add(std::move(sn_entry));
-                } else if (!fork_collapsed_to_source) {
-                    // Normal path: capture old checkpoint state to safety net
-                    // before cleaning up. Skip if fork_collapsed_to_source
-                    // already captured (avoids redundant D2H copy).
-                    // This ensures the spill can merge checkpoint state
-                    // even after DropOptional clears the new rewrite_state.
-                    if (state_images && continuation_index < continuation_capacity &&
-                        state.rewrite_checkpoint.valid &&
-                        state.rewrite_checkpoint.frontier != 0) {
-                        // rewrite_checkpoint is valid — capture the old state.
-                        const std::size_t cap_bytes = state_images->host_layout().image_bytes;
-                        // rewrite_state was already released at L9657, but
-                        // state.state.read still has the turn-boundary state.
-                        // Use it as the checkpoint state source.
-                        const StateReplicaResidency cap_residency =
-                            state_store->residency(state.state.read);
-                        if (cap_bytes > 0 && state_store->valid(state.state.read) &&
-                            (cap_residency == StateReplicaResidency::DeviceOnly ||
-                             cap_residency == StateReplicaResidency::Both)) {
-                            std::vector<std::byte> cap_host(cap_bytes);
-                            const std::int32_t cap_slot =
-                                state_store->physical_slot(state.state.read);
-                            const HostStateImageView cap_view{
-                                .data = cap_host.data(),
-                                .layout = &state_images->host_layout()};
-                            state_images->copy_to_host(cap_slot, cap_view, device.transfer_stream);
-                            CUDA_CHECK(cudaStreamSynchronize(device.transfer_stream));
-                            host_kv_safety_net.remove_state_only_by_index(continuation_index);
-                            if (state.session_key) {
-                                host_kv_safety_net.remove_state_only(*state.session_key);
-                            }
-                            HostKVSafetyNetEntry sn_entry;
-                            sn_entry.state_only = true;
-                            sn_entry.source_continuation_index = continuation_index;
-                            sn_entry.checkpoint_valid = true;
-                            sn_entry.checkpoint_frontier = state.rewrite_checkpoint.frontier;
-                            sn_entry.checkpoint_state_host = std::move(cap_host);
-                            sn_entry.checkpoint_state_bytes = cap_bytes;
-                            sn_entry.session_key = state.session_key;
-                            sn_entry.execution_frontier = 0;
-                            std::fprintf(stderr,
-                                "[checkpoint-demoted] finish-normal: index=%u frontier=%u ckpt_frontier=%u "
-                                "state_bytes=%zu\n",
-                                continuation_index, state.execution_frontier,
-                                state.rewrite_checkpoint.frontier, cap_bytes);
-                            host_kv_safety_net.add(std::move(sn_entry));
-                        }
-                    } else {
-                        // rewrite_checkpoint not valid (DropOptional cleared it).
-                        // DON'T clean up state-only entries — the advance_prefill
-                        // capture may have created one that the spill needs.
-                        // Cleanup happens via spill merge or slot recycling.
-                    }
+                                 "[checkpoint] unit-not-retained: demoted checkpoint state has "
+                                 "no complete {KV + state} unit\n");
                 }
             } else {
-                // Cannot reserve a new CheckpointImmutable image for the
-                // rewrite state. If demotion happened, save the captured
-                // state to the safety net so it is not lost.
+                // Cannot reserve a new CheckpointImmutable image for the rewrite state. The
+                // demoted state is not retained on its own for the same reason as above.
                 if (demoted_from_host && !demoted_host_buffer.empty()) {
-                    host_kv_safety_net.remove_state_only_by_index(continuation_index);
-                    if (state.session_key) {
-                        host_kv_safety_net.remove_state_only(*state.session_key);
-                    }
-                    HostKVSafetyNetEntry sn_entry;
-                    sn_entry.state_only = true;
-                    sn_entry.source_continuation_index = continuation_index;
-                    sn_entry.checkpoint_valid = true;
-                    sn_entry.checkpoint_frontier = state.rewrite_checkpoint.frontier;
-                    sn_entry.checkpoint_state_host = std::move(demoted_host_buffer);
-                    sn_entry.checkpoint_state_bytes = state_images->host_layout().image_bytes;
-                    sn_entry.session_key = state.session_key;
-                    sn_entry.execution_frontier = 0;
                     std::fprintf(stderr,
-                        "[checkpoint-demoted] finish-fallback: index=%u ckpt_frontier=%u "
-                        "state_bytes=%zu (reserve_destination failed after demotion)\n",
-                        continuation_index, state.rewrite_checkpoint.frontier,
-                        static_cast<std::size_t>(state_images->host_layout().image_bytes));
-                    host_kv_safety_net.add(std::move(sn_entry));
+                                 "[checkpoint] unit-not-retained: demoted checkpoint state has "
+                                 "no complete {KV + state} unit (reserve_destination failed)\n");
                 }
                 // state.read image is still valid and retains the
                 // turn-boundary state for in-place continuation.
@@ -10684,12 +10490,6 @@ void ProgramImplCore::start_sequence(std::uint32_t lane, SequenceState& sequence
                     state_store->freeze(*new_rewrite);
                     state_store->retain_checkpoint_reference(*new_rewrite);
                     sequence.rewrite_state = *new_rewrite;
-                    // Clean up stale state-only safety net entries — the
-                    // new rewrite checkpoint supersedes them.
-                    host_kv_safety_net.remove_state_only_by_index(active_continuations[sequence.lane]);
-                    if (sequence.session_key) {
-                        host_kv_safety_net.remove_state_only(*sequence.session_key);
-                    }
                 } else {
                     // No device slot for the new checkpoint. The pressure
                     // planner should have made room (via request_plan_impl.h
@@ -10880,7 +10680,8 @@ void ProgramImplCore::start_sequence(std::uint32_t lane, SequenceState& sequence
             // Re-add the entry to the safety net so the same session's next
             // root-path request can still match. The H2D copy did not modify
             // the host KV buffers; the entry is still valid for future restores.
-            // Refresh the timestamp so LRU eviction treats it as recently used.
+            // Refresh the timestamp: eviction is cost-aware (smallest unit first), so
+            // recency only matters when comparing units of similar size.
             entry.pinned = false;
             entry.created = std::chrono::steady_clock::now();
             host_kv_safety_net.add(std::move(entry));
@@ -11982,6 +11783,39 @@ void ProgramImplCore::prepare_graphs() {
     release_capture_rows(*text_kv_addresses, text_capture_allocations);
 }
 
+void ProgramImplCore::update_sampling(SequenceHandle sequence_handle,
+                                      const runtime::ResolvedSamplingParameters& sampling) {
+    if (!valid_sequence(sequence_handle)) {
+        throw std::logic_error("update_sampling sequence capability is invalid");
+    }
+    const std::uint32_t lane = ContractAccess::lane(sequence_handle).value;
+    if (lane >= max_concurrency || requests[lane].lifecycle != Lifecycle::Active) {
+        throw std::logic_error("update_sampling target is not active");
+    }
+    ops::SamplingConfig config;
+    config.temperature       = sampling.temperature;
+    config.top_k             = sampling.top_k;
+    config.top_p             = sampling.top_p;
+    config.min_p             = sampling.min_p;
+    config.presence_penalty  = sampling.presence_penalty;
+    config.frequency_penalty = sampling.frequency_penalty;
+    config.seed              = sampling.seed;
+    config.token_counts      = nullptr;
+    RequestControl& request = requests[lane];
+    request.sampling_host   = config;
+    const bool penalties = config.presence_penalty != 0.0F || config.frequency_penalty != 0.0F;
+    if (penalties) {
+        Tensor counts = token_counts.slice(1, static_cast<std::int32_t>(lane), 1)
+                            .view({TextConfig::token_domain});
+        CUDA_CHECK(cudaMemsetAsync(counts.data, 0, counts.bytes(), device.stream));
+        request.sampling_host.token_counts = static_cast<std::int32_t*>(counts.data);
+    }
+    Tensor config_lane = sampling_config.slice(1, static_cast<std::int32_t>(lane), 1);
+    CUDA_CHECK(cudaMemcpyAsync(config_lane.data, &request.sampling_host,
+                               sizeof(request.sampling_host), cudaMemcpyHostToDevice,
+                               device.stream));
+}
+
 void ProgramImplCore::install_sampling(SequenceState& sequence, RequestControl& request,
                                        const ops::SamplingConfig& config) {
     Tensor counts = token_counts.slice(1, static_cast<std::int32_t>(sequence.lane), 1)
@@ -12331,49 +12165,16 @@ ProgramImplCore::advance_prefill(SequenceState& sequence, RequestControl& reques
             // NOTE: staged.cursor == staged.prompt_tokens is already verified
             // above; sequence.execution_frontier is NOT yet updated at this point
             // (it's committed with the prefill result), so don't check it here.
-            // NOTE: staged.cursor == staged.prompt_tokens is already verified
-            // above; sequence.execution_frontier is NOT yet updated at this point
-            // (it's committed with the prefill result), so don't check it here.
+            // Prefill-completion state capture is NOT performed here. A cache unit is
+            // {KV + state}: this path holds a state image while the continuation's
+            // attention KV is not part of the entry, so retaining the state alone is not
+            // a restorable unit - it was the unbounded host-memory growth this change
+            // removes. Retention belongs to the spill path, which stores a complete unit
+            // or nothing and performs its own D2H copy, so nothing is copied here.
             if (!sequence.rewrite_checkpoint.valid && state_store && state_images) {
-                const std::uint32_t capture_index = active_continuations[sequence.lane];
-                if (capture_index < continuation_capacity) {
-                    const std::size_t capture_bytes = state_images->host_layout().image_bytes;
-                    const StateReplicaResidency residency =
-                        state_store->residency(sequence.state.write);
-                    if (capture_bytes > 0 &&
-                        (residency == StateReplicaResidency::DeviceOnly ||
-                         residency == StateReplicaResidency::Both)) {
-                        // Unified architecture: create a state-only safety net entry
-                        // instead of using the dropped_checkpoint_captures_ side store.
-                        std::vector<std::byte> capture_host(capture_bytes);
-                        const std::int32_t capture_slot = state_store->physical_slot(sequence.state.write);
-                        const HostStateImageView capture_view{
-                            .data = capture_host.data(),
-                            .layout = &state_images->host_layout()};
-                        state_images->copy_to_host(capture_slot, capture_view, device.transfer_stream);
-                        CUDA_CHECK(cudaStreamSynchronize(device.transfer_stream));
-                        HostKVSafetyNetEntry sn_entry;
-                        sn_entry.state_only = true;
-                        sn_entry.source_continuation_index = capture_index;
-                        sn_entry.checkpoint_valid = true;
-                        sn_entry.checkpoint_frontier = staged.prompt_tokens;
-                        sn_entry.checkpoint_state_host = std::move(capture_host);
-                        sn_entry.checkpoint_state_bytes = capture_bytes;
-                        sn_entry.session_key = sequence.session_key;
-                        sn_entry.execution_frontier = 0;
-                        // Remove stale state-only entries before adding.
-                        host_kv_safety_net.remove_state_only_by_index(capture_index);
-                        if (sequence.session_key) {
-                            host_kv_safety_net.remove_state_only(*sequence.session_key);
-                        }
-                        std::fprintf(stderr,
-                            "[checkpoint-demoted] prefill: index=%u frontier=%u ckpt_frontier=%u "
-                            "state_bytes=%zu\n",
-                            capture_index, sequence.execution_frontier,
-                            static_cast<unsigned>(staged.prompt_tokens), capture_bytes);
-                        host_kv_safety_net.add(std::move(sn_entry));
-                    }
-                }
+                std::fprintf(stderr,
+                             "[checkpoint] unit-not-retained: prefill-completion state has no "
+                             "complete {KV + state} unit\n");
             }
             timing.resume_submit();
             copy_tail(sequence, prefill_hidden.slice(
@@ -13122,7 +12923,11 @@ MemorySummary ProgramImplCore::memory_summary() const noexcept {
     }
     if (host_kv_arena) {
         out.host_kv_capacity_bytes = host_kv_arena->capacity_bytes();
-        out.host_kv_occupied_bytes = host_kv_arena->occupied_bytes();
+        // Host KV pages and retained state images share one host-memory budget:
+        // state images are heap-backed today, so report them alongside arena bytes
+        // instead of hiding them from the occupancy the budget governs.
+        out.host_kv_occupied_bytes =
+            host_kv_arena->occupied_bytes() + host_kv_safety_net.retained_state_bytes();
     }
     return out;
 }

--- a/src/targets/qwen3_6_27b/impl/package.cpp
+++ b/src/targets/qwen3_6_27b/impl/package.cpp
@@ -49,12 +49,19 @@ constexpr ModelSamplingDefaults kQwen3_6Defaults{
                      .min_p             = 0.0F,
                      .presence_penalty  = 0.0F,
                      .frequency_penalty = 0.0F},
+    .post_thinking = {.temperature       = 0.2F,
+                      .top_k             = 20,
+                      .top_p             = 0.95F,
+                      .min_p             = 0.0F,
+                      .presence_penalty  = 0.0F,
+                      .frequency_penalty = 0.0F},
     .non_thinking = {.temperature       = 0.7F,
                      .top_k             = 20,
                      .top_p             = 0.80F,
                      .min_p             = 0.0F,
                      .presence_penalty  = 1.5F,
                      .frequency_penalty = 0.0F},
+    .has_post_thinking = true,
 };
 
 constexpr ModelSamplingDefaults kQwen3_8Defaults{
@@ -64,12 +71,19 @@ constexpr ModelSamplingDefaults kQwen3_8Defaults{
                      .min_p             = 0.0F,
                      .presence_penalty  = 0.0F,
                      .frequency_penalty = 0.0F},
+    .post_thinking = {.temperature       = 0.2F,
+                      .top_k             = 20,
+                      .top_p             = 0.95F,
+                      .min_p             = 0.0F,
+                      .presence_penalty  = 0.0F,
+                      .frequency_penalty = 0.0F},
     .non_thinking = {.temperature       = 0.7F,
                      .top_k             = 20,
                      .top_p             = 0.80F,
                      .min_p             = 0.0F,
                      .presence_penalty  = 1.5F,
                      .frequency_penalty = 0.0F},
+    .has_post_thinking = true,
 };
 
 } // namespace

--- a/src/targets/qwen3_6_35b_a3b/impl/package.cpp
+++ b/src/targets/qwen3_6_35b_a3b/impl/package.cpp
@@ -47,12 +47,19 @@ constexpr ModelSamplingDefaults kQwen3_6_35BA3BDefaults{
                      .min_p             = 0.0F,
                      .presence_penalty  = 1.5F,
                      .frequency_penalty = 0.0F},
+    .post_thinking = {.temperature       = 0.2F,
+                      .top_k             = 20,
+                      .top_p             = 0.95F,
+                      .min_p             = 0.0F,
+                      .presence_penalty  = 1.5F,
+                      .frequency_penalty = 0.0F},
     .non_thinking = {.temperature       = 0.7F,
                      .top_k             = 20,
                      .top_p             = 0.80F,
                      .min_p             = 0.0F,
                      .presence_penalty  = 1.5F,
                      .frequency_penalty = 0.0F},
+    .has_post_thinking = true,
 };
 
 } // namespace

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -114,6 +114,7 @@ ninfer_add_test(ninfer_qwen3_6_frontend_test
   SOURCES targets/qwen3_6/test_frontend.cpp
   NEEDS_SOURCE_DIR
   LIBRARIES ninfer_engine ninfer_core)
+set_tests_properties(ninfer_qwen3_6_frontend_test PROPERTIES SKIP_RETURN_CODE 77)
 target_include_directories(ninfer_qwen3_6_frontend_test PRIVATE
   ${PROJECT_SOURCE_DIR}/src/targets/qwen3_6/export
   ${PROJECT_SOURCE_DIR}/src/targets/qwen3_6/impl)

--- a/tests/targets/qwen3_6/test_frontend.cpp
+++ b/tests/targets/qwen3_6/test_frontend.cpp
@@ -17,9 +17,12 @@
 #include <bit>
 #include <chrono>
 #include <cmath>
+#include <cstdlib>
 #include <cstddef>
 #include <cstdint>
+#include <filesystem>
 #include <fstream>
+#include <optional>
 #include <future>
 #include <iostream>
 #include <iterator>
@@ -111,16 +114,55 @@ const fi::CompiledChatTemplate& reasoning_effort_template() {
     return value;
 }
 
+FrontendResources resources(const std::string& chat_template = thinking_toggle_template_source());
+
+// Directory holding the official Qwen3.6-27B base checkpoint resources (tokenizer.json,
+// tokenizer_config.json, generation_config.json). NINFER_QWEN3_6_27B_BASE overrides the
+// legacy maintainer-checkout location.
+std::optional<std::filesystem::path> official_base_dir() {
+    static const std::optional<std::filesystem::path> dir =
+        []() -> std::optional<std::filesystem::path> {
+        const auto complete = [](const std::filesystem::path& dir) {
+            return std::filesystem::is_regular_file(dir / "tokenizer.json") &&
+                   std::filesystem::is_regular_file(dir / "tokenizer_config.json") &&
+                   std::filesystem::is_regular_file(dir / "generation_config.json");
+        };
+        if (const char* base = std::getenv("NINFER_QWEN3_6_27B_BASE"); base != nullptr && *base != '\0') {
+            const std::filesystem::path candidate(base);
+            if (complete(candidate)) { return candidate; }
+        }
+        const std::filesystem::path legacy("/home/neroued/models/llm/qwen/Qwen3.6-27B/base-hf-bf16");
+        if (complete(legacy)) { return legacy; }
+        return std::nullopt;
+    }();
+    return dir;
+}
+
+std::string official_tokenizer_file(const char* name) {
+    const auto dir = official_base_dir();
+    if (!dir) {
+        throw std::runtime_error("official Qwen3.6-27B tokenizer resources are unavailable");
+    }
+    return read_file((dir->string() + "/" + name).c_str());
+}
+
+FrontendResources official_resources() {
+    FrontendResources res = resources();
+    res.tokenizer_json         = official_tokenizer_file("tokenizer.json");
+    res.tokenizer_config_json  = official_tokenizer_file("tokenizer_config.json");
+    res.generation_config_json = official_tokenizer_file("generation_config.json");
+    return res;
+}
+
 const fi::Tokenizer& official_tokenizer() {
-    static const std::string tokenizer_json =
-        read_file("/home/neroued/models/llm/qwen/Qwen3.6-27B/base-hf-bf16/tokenizer.json");
-    static const std::string tokenizer_config_json =
-        read_file("/home/neroued/models/llm/qwen/Qwen3.6-27B/base-hf-bf16/tokenizer_config.json");
-    static const std::string generation_config_json =
-        read_file("/home/neroued/models/llm/qwen/Qwen3.6-27B/base-hf-bf16/generation_config.json");
-    static const fi::Tokenizer tokenizer({.tokenizer_json         = tokenizer_json,
-                                          .tokenizer_config_json  = tokenizer_config_json,
-                                          .generation_config_json = generation_config_json});
+    static const fi::Tokenizer tokenizer = [] {
+        const FrontendResources res = official_resources();
+        const fi::TokenizerResources resources{
+            .tokenizer_json         = res.tokenizer_json,
+            .tokenizer_config_json  = res.tokenizer_config_json,
+            .generation_config_json = res.generation_config_json};
+        return fi::Tokenizer(resources);
+    }();
     return tokenizer;
 }
 
@@ -154,7 +196,7 @@ std::string byte_level_symbol(std::uint8_t target) {
     throw std::logic_error("byte-level test symbol is outside one byte");
 }
 
-FrontendResources resources(const std::string& chat_template = thinking_toggle_template_source()) {
+FrontendResources resources(const std::string& chat_template) {
     FrontendResources result;
     result.chat_template_jinja  = chat_template;
     const nlohmann::json tokens = nlohmann::json::array(
@@ -1221,13 +1263,7 @@ int test_literal_control_tokens_with_media() {
             "<|im_start|>user\n<tool_response>\nimported result\n</tool_response><|im_end|>\n",
         "leading tool result was rendered without its user-role envelope");
 
-    FrontendResources official = resources();
-    official.tokenizer_json =
-        read_file("/home/neroued/models/llm/qwen/Qwen3.6-27B/base-hf-bf16/tokenizer.json");
-    official.tokenizer_config_json =
-        read_file("/home/neroued/models/llm/qwen/Qwen3.6-27B/base-hf-bf16/tokenizer_config.json");
-    official.generation_config_json =
-        read_file("/home/neroued/models/llm/qwen/Qwen3.6-27B/base-hf-bf16/generation_config.json");
+    FrontendResources official = official_resources();
     const Frontend frontend = FrontendFactory::create_component(official);
 
     auto text_part = [](std::string text) {
@@ -1372,13 +1408,7 @@ int test_image_resize_rejection_policy() {
 }
 
 int test_explicit_leading_instruction_cache_boundary() {
-    FrontendResources official = resources();
-    official.tokenizer_json =
-        read_file("/home/neroued/models/llm/qwen/Qwen3.6-27B/base-hf-bf16/tokenizer.json");
-    official.tokenizer_config_json =
-        read_file("/home/neroued/models/llm/qwen/Qwen3.6-27B/base-hf-bf16/tokenizer_config.json");
-    official.generation_config_json =
-        read_file("/home/neroued/models/llm/qwen/Qwen3.6-27B/base-hf-bf16/generation_config.json");
+    FrontendResources official = official_resources();
     const Frontend frontend           = FrontendFactory::create_component(official, false);
     constexpr std::string_view stable = "stable cache section.";
     ninfer::ChatMessage system;
@@ -1621,13 +1651,7 @@ int test_terminal_flush(const Frontend& frontend) {
 }
 
 int test_structured_tool_output() {
-    FrontendResources owned = resources();
-    owned.tokenizer_json =
-        read_file("/home/neroued/models/llm/qwen/Qwen3.6-27B/base-hf-bf16/tokenizer.json");
-    owned.tokenizer_config_json =
-        read_file("/home/neroued/models/llm/qwen/Qwen3.6-27B/base-hf-bf16/tokenizer_config.json");
-    owned.generation_config_json =
-        read_file("/home/neroued/models/llm/qwen/Qwen3.6-27B/base-hf-bf16/generation_config.json");
+    FrontendResources owned = official_resources();
     const Frontend frontend = FrontendFactory::create_component(owned);
 
     ninfer::ChatMessage message;
@@ -1688,6 +1712,38 @@ int test_reasoning_split(const Frontend& frontend) {
                       "content channel did not strip the post-thinking separator");
     failures += check(session.reasoning_tokens() == 2,
                       "reasoning token usage did not count accepted reasoning tokens exactly");
+    return failures;
+}
+
+// The post-thinking sampler switch keys off this transition: the output session reports the
+// reasoning block closed only after the round carrying the close marker is committed.
+int test_post_thinking_phase_switch(const Frontend& frontend) {
+    ninfer::ChatMessage message;
+    message.role = ninfer::ChatRole::User;
+    message.parts.push_back(
+        ninfer::MessagePart{.kind = ninfer::MessagePartKind::Text, .text = "x", .media = {}});
+    ninfer::PromptInput input;
+    input.messages.push_back(std::move(message));
+    input.options.continuation    = ninfer::PromptContinuationMode::NewAssistantTurn;
+    input.options.enable_thinking = true;
+    const auto prompt = frontend.prepare(std::move(input));
+    auto session      = frontend.make_output_session(prompt, {});
+
+    int failures = check(!session.reasoning_closed(),
+                         "thinking session reports the reasoning block closed before any output");
+    // Fixture tokens 3+4 decode to the reasoning text, the close marker, and the answer.
+    const std::array<ninfer::TokenId, 2> tokens{3, 4};
+    const auto decision = session.preview_model(tokens, 8, ninfer::FinishReason::OutputLimit);
+    failures += check(decision.accepted_tokens == 2 && !decision.finished(),
+                      "reasoning-close round did not accept both tokens");
+    failures += check(!session.reasoning_closed(),
+                         "reasoning close reported before the preview was committed");
+    const auto output = session.commit_preview();
+    failures += check(session.reasoning_closed(),
+                      "committed close marker did not open the post-thinking phase");
+    failures += check(channel_text(output, ninfer::OutputChannel::Reasoning) == "thought" &&
+                          channel_text(output, ninfer::OutputChannel::Content) == "answer",
+                      "post-thinking round did not route the channels around the close marker");
     return failures;
 }
 
@@ -2169,6 +2225,11 @@ int test_media_preparation_cancellation() {
 } // namespace
 
 int main() {
+    if (!official_base_dir()) {
+        std::cerr << "SKIP: Qwen3.6-27B base tokenizer resources not found; "
+                     "set NINFER_QWEN3_6_27B_BASE to a base-hf-bf16 directory\n";
+        return 77;
+    }
     const FrontendResources owned = resources();
     const Frontend frontend       = FrontendFactory::create_component(owned);
     int failures                  = 0;
@@ -2200,6 +2261,7 @@ int main() {
     failures += test_terminal_flush(frontend);
     failures += test_structured_tool_output();
     failures += test_reasoning_split(frontend);
+    failures += test_post_thinking_phase_switch(frontend);
     failures += test_thinking_budget_control(frontend);
     failures += test_utf8_and_hidden_eos(frontend);
     failures += test_media_cache_reuses_immutable_payload();

--- a/tests/test_anthropic_schema.cpp
+++ b/tests/test_anthropic_schema.cpp
@@ -88,7 +88,8 @@ ResolvedPromptSemantics semantics(const GenerationRequest& request, bool default
 }
 
 ninfer::PromptInput prompt(const GenerationRequest& request) {
-    return to_prompt_input(request, semantics(request), [](const ContentPart& part) {
+    ServeOptions server;
+    return to_prompt_input(request, server, semantics(request), [](const ContentPart& part) {
         ninfer::OwnedMedia media;
         media.kind =
             part.kind == ContentKind::Image ? ninfer::MediaKind::Image : ninfer::MediaKind::Video;
@@ -414,6 +415,37 @@ int test_thinking_and_count_tokens() {
     return failures;
 }
 
+int test_post_thinking_sampling() {
+    Json body = base_request();
+    body["post_thinking"] = Json{{"temperature", 0.2}, {"top_p", 0.9}, {"top_k", 7}};
+    const GenerationRequest request = parse(body).generation;
+    int failures = check(request.post_thinking.temperature &&
+                             *request.post_thinking.temperature == 0.2 &&
+                             request.post_thinking.top_k &&
+                             *request.post_thinking.top_k == 7,
+                         "post_thinking object parsed");
+    const ninfer::RequestOptions options =
+        to_request_options(request, ServeOptions{}, semantics(request), true);
+    failures += check(options.execution.post_thinking_sampling.temperature &&
+                           *options.execution.post_thinking_sampling.temperature == 0.2F &&
+                           *options.execution.post_thinking_sampling.top_p == 0.9F &&
+                           *options.execution.post_thinking_sampling.top_k == 7,
+                       "post_thinking reaches Engine request options");
+
+    body["post_thinking"] = nullptr;
+    failures += check(!parse(body).generation.post_thinking.temperature,
+                      "post_thinking null treated as unset");
+
+    body["post_thinking"] = "text";
+    failures += check(api_param([&] { (void)parse(body); }) == "post_thinking",
+                      "non-object post_thinking rejected");
+
+    body["post_thinking"] = Json{{"temperature", 3.0}};
+    failures += check(api_param([&] { (void)parse(body); }) == "post_thinking",
+                      "out-of-range post_thinking temperature rejected");
+    return failures;
+}
+
 int test_thinking_history_integrity() {
     constexpr std::string_view thought = "thought";
     const std::string signature        = thinking_signer().sign(thought, 0);
@@ -670,6 +702,7 @@ int main() {
     failures += test_tool_history();
     failures += test_tools();
     failures += test_thinking_and_count_tokens();
+    failures += test_post_thinking_sampling();
     failures += test_thinking_history_integrity();
     failures += test_content_and_cache_hints();
     failures += test_aggregate_and_errors();

--- a/tests/test_cli_options.cpp
+++ b/tests/test_cli_options.cpp
@@ -54,6 +54,54 @@ int main() {
                "--reasoning-effort", "medium"});
     failures += check(with_effort.thinking_budget == 8 && with_effort.reasoning_effort,
                       "thinking budget did not coexist with reasoning effort");
+
+    const ninfer::cli::Options post_thinking =
+        parse({"ninfer-cli", "model.ninfer", "--prompt", "hello",
+               "--post-thinking-temperature", "0.2", "--post-thinking-top-p", "0.9",
+               "--post-thinking-top-k", "5"});
+    failures += check(post_thinking.post_thinking_sampling.temperature &&
+                          *post_thinking.post_thinking_sampling.temperature == 0.2F &&
+                          *post_thinking.post_thinking_sampling.top_p == 0.9F &&
+                          post_thinking.post_thinking_sampling.top_k &&
+                          *post_thinking.post_thinking_sampling.top_k == 5,
+                      "post-thinking flags did not land in the post-thinking overrides");
+    failures += check(!post_thinking.sampling.temperature,
+                      "post-thinking flags leaked into the main sampling overrides");
+    const ninfer::cli::Options post_thinking_combined = parse(
+        {"ninfer-cli", "model.ninfer", "--prompt", "hello",
+         "--post-thinking-sampler", "temp=0.25,top_p=0.9,top_k=7,min_p=0.1,presence=0.5,frequency=0.25"});
+    failures += check(post_thinking_combined.post_thinking_sampling.temperature &&
+                          *post_thinking_combined.post_thinking_sampling.temperature == 0.25F &&
+                          *post_thinking_combined.post_thinking_sampling.top_p == 0.9F &&
+                          *post_thinking_combined.post_thinking_sampling.top_k == 7 &&
+                          *post_thinking_combined.post_thinking_sampling.min_p == 0.1F &&
+                          *post_thinking_combined.post_thinking_sampling.presence_penalty ==
+                              0.5F &&
+                          *post_thinking_combined.post_thinking_sampling.frequency_penalty ==
+                              0.25F,
+                      "combined --post-thinking-sampler did not populate every field");
+    failures += check(rejects([] {
+                          (void)parse({"ninfer-cli", "model.ninfer", "--prompt", "hello",
+                                       "--post-thinking-top-k", "21"});
+                      }),
+                      "out-of-range --post-thinking-top-k was accepted");
+    failures += check(
+        rejects([] {
+            (void)parse({"ninfer-cli", "model.ninfer", "--prompt", "hello",
+                         "--post-thinking-sampler", "bogus"});
+        }),
+        "malformed --post-thinking-sampler field was accepted");
+    failures += check(
+        rejects([] {
+            (void)parse({"ninfer-cli", "model.ninfer", "--prompt", "hello",
+                         "--post-thinking-sampler", "temp=abc"});
+        }),
+        "non-numeric --post-thinking-sampler value was accepted");
+    const ninfer::cli::Options greedy =
+        parse({"ninfer-cli", "model.ninfer", "--prompt", "hello", "--greedy"});
+    failures += check(*greedy.sampling.temperature == 0.0F &&
+                          *greedy.post_thinking_sampling.temperature == 0.0F,
+                      "--greedy did not force both sampling phases to exact argmax");
     failures +=
         check(rejects([] {
                   (void)parse({"ninfer-cli", "model.ninfer", "--prompt", "hello", "--top-k", "21"});

--- a/tests/test_host_state_memory_bounded.py
+++ b/tests/test_host_state_memory_bounded.py
@@ -1,0 +1,174 @@
+"""E2E: host memory must stay bounded under sustained distinct conversations.
+
+Regression test for unbounded retention of state-only host-KV safety-net entries.
+
+Observed failure (RTX 5090, 55 GB WSL VM, 2026-09-11): each distinct conversation
+that demotes a checkpoint state image leaves a state-only entry holding a host
+state image (~147 MiB). Entries accumulate at roughly two per conversation with no
+plateau, while the accounted host KV stays well below its configured capacity,
+because state images are ordinary heap allocations and not host-KV arena bytes.
+RSS therefore grows linearly until the OOM killer fires.
+
+The assertion is a bound on retained memory, not a wait for OOM, so the test fails
+while the defect exists and passes once retention is correctly bounded.
+
+Skipped unless the serve binary and a real artifact are available:
+
+    NINFER_HOSTMEM_TEST=1 \
+    NINFER_HOSTMEM_ARTIFACT=/path/to/model.ninfer \
+    NINFER_HOSTMEM_SERVE=/path/to/build/apps/ninfer-serve \
+    pytest tests/test_host_state_memory_bounded.py -s
+"""
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import time
+import urllib.request
+
+import pytest
+
+ARTIFACT = os.environ.get("NINFER_HOSTMEM_ARTIFACT", "")
+SERVE = os.environ.get("NINFER_HOSTMEM_SERVE", "")
+ENABLED = os.environ.get("NINFER_HOSTMEM_TEST") == "1"
+PORT = int(os.environ.get("NINFER_HOSTMEM_PORT", "18099"))
+
+# Bounds. Retention must be a function of the configured capacity, not of how many
+# conversations the server has seen.
+MAX_RSS_GROWTH_GIB = 6.0
+CONVERSATIONS = 30
+
+pytestmark = pytest.mark.skipif(
+    not (ENABLED and ARTIFACT and SERVE and os.path.exists(ARTIFACT) and os.path.exists(SERVE)),
+    reason="set NINFER_HOSTMEM_TEST=1 and NINFER_HOSTMEM_ARTIFACT/NINFER_HOSTMEM_SERVE to run",
+)
+
+
+def _post(payload):
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{PORT}/v1/chat/completions",
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=600) as r:
+        return json.loads(r.read().decode())
+
+
+def _rss_gib(pid):
+    with open(f"/proc/{pid}/status") as f:
+        for line in f:
+            if line.startswith("VmRSS:"):
+                return int(line.split()[1]) / 1048576.0
+    return 0.0
+
+
+def get_stats():
+    with urllib.request.urlopen(f"http://127.0.0.1:{PORT}/stats", timeout=10) as r:
+        return json.loads(r.read().decode())
+
+
+def _count(log_path, needle):
+    """Occurrences of a diagnostic in the server log."""
+    return open(log_path, errors="replace").read().count(needle)
+
+
+def _host_occupancy(stats):
+    """Occupancy and capacity of the shared host budget (GiB)."""
+    memory = stats.get("memory", {}) or {}
+    return (
+        memory.get("host_kv_occupied_bytes", 0) / 1073741824.0,
+        memory.get("host_kv_capacity_bytes", 0) / 1073741824.0,
+    )
+
+
+def _prompt(i, approx_tokens=900):
+    return (f"Case {i}. Read the following notes and reply with a one-sentence summary.\n\n"
+            + ("Consider the value table for case %d. " % i) * max(1, int(approx_tokens / 6)))
+
+
+def test_host_memory_stays_bounded_across_conversations(tmp_path):
+    log_path = tmp_path / "server.log"
+    args = [
+        SERVE, ARTIFACT,
+        "--host", "127.0.0.1", "--port", str(PORT), "--model-id", "qwen3.8-27b",
+        "--max-concurrency", "2",
+        "--max-context", "32768",
+        "--kv-capacity", "auto",
+        "--default-max-tokens", "192",
+        "--kv-dtype", "int8",
+        "--spec", "mtp", "--draft-tokens", "5", "--lm-head-draft",
+        "--host-kv-mib", "4096",
+        "--host-state-slots", "8",
+        "--max-private-continuations", "18",
+        "--max-shared-prefixes", "6",
+        "--seed", "42",
+        "--temperature", "0.7", "--top-p", "0.8", "--top-k", "20",
+    ]
+    with open(log_path, "w") as log:
+        server = subprocess.Popen(args, stdout=log, stderr=subprocess.STDOUT)
+        try:
+            deadline = time.time() + 300
+            while time.time() < deadline:
+                try:
+                    urllib.request.urlopen(f"http://127.0.0.1:{PORT}/stats", timeout=5).read()
+                    break
+                except Exception:
+                    if server.poll() is not None:
+                        pytest.fail(f"server exited during startup: {log_path.read_text()[-2000:]}")
+                    time.sleep(2)
+            else:
+                pytest.fail("server did not become healthy")
+
+            baseline = _rss_gib(server.pid)
+            for i in range(CONVERSATIONS):
+                user = _prompt(i)
+                reply = _post({
+                    "model": "qwen3.8-27b",
+                    "messages": [{"role": "user", "content": user}],
+                    "max_tokens": 192, "seed": 42, "enable_thinking": True,
+                })["choices"][0]["message"].get("content") or ""
+                _post({
+                    "model": "qwen3.8-27b",
+                    "messages": [
+                        {"role": "user", "content": user},
+                        {"role": "assistant", "content": reply or "ok"},
+                        {"role": "user", "content": f"Now restate case {i} in one line."},
+                    ],
+                    "max_tokens": 192, "seed": 42, "enable_thinking": True,
+                })
+                growth = _rss_gib(server.pid) - baseline
+                assert growth < MAX_RSS_GROWTH_GIB, (
+                    f"host RSS grew {growth:.2f} GiB after {i + 1} conversations "
+                    f"(baseline {baseline:.2f} GiB); retained state images must be "
+                    "bounded by the configured host budget"
+                )
+                occupied, capacity = _host_occupancy(get_stats())
+                assert occupied <= capacity, (
+                    f"reported host occupancy {occupied:.2f} GiB exceeds the shared host "
+                    f"budget {capacity:.2f} GiB after {i + 1} conversations; host KV pages "
+                    "and retained state images must share one budget"
+                )
+                # Atomicity: a cache unit is {attention KV + GDN state}. The spill path must
+                # retain a complete unit or nothing, so a half unit must never reach the
+                # retention boundary. A partial unit would also be a correctness hazard,
+                # since prefix matching could select it and restore a wrong continuation.
+                partial = _count(log_path, "[safety-net] REJECT-PARTIAL")
+                assert partial == 0, (
+                    f"{partial} partial units were offered for retention; KV and state are one "
+                    "atomic unit and must be retained together or not at all"
+                )
+            # Retention must still work: a change that only refuses half units would
+            # silently disable unit retention altogether, which is a regression.
+            retained = _count(log_path, "[safety-spill] OK")
+            assert retained > 0, (
+                "no complete {KV + state} unit was retained during the run; the spill path "
+                "must still store whole units, not merely refuse half ones"
+            )
+        finally:
+            server.send_signal(signal.SIGTERM)
+            try:
+                server.wait(timeout=30)
+            except Exception:
+                server.kill()

--- a/tests/test_openai_responses.cpp
+++ b/tests/test_openai_responses.cpp
@@ -161,6 +161,48 @@ int test_basic_request_and_resolution() {
     return failures;
 }
 
+int test_post_thinking_sampling() {
+    const Json body = {{"model", "m"},
+                       {"input", "hello"},
+                       {"post_thinking",
+                        Json{{"temperature", 0.2},
+                             {"top_p", 0.9},
+                             {"top_k", 7},
+                             {"min_p", 0.1},
+                             {"presence_penalty", 0.5},
+                             {"frequency_penalty", -0.25},
+                             {"seed", 42}}}};
+    const OpenAIResponsesCreateRequest request =
+        parse_openai_responses_create_request(body, limits());
+    const SamplingParams& pt = request.prompt.generation.post_thinking;
+    int failures = check(pt.temperature && *pt.temperature == 0.2 &&
+                             pt.top_k && *pt.top_k == 7 && pt.min_p && *pt.min_p == 0.1 &&
+                             pt.presence_penalty && *pt.presence_penalty == 0.5 &&
+                             pt.frequency_penalty && *pt.frequency_penalty == -0.25 &&
+                             pt.seed && *pt.seed == 42,
+                         "post_thinking object parsed with the full field set");
+
+    const Json null_body = {{"model", "m"}, {"input", "hello"}, {"post_thinking", nullptr}};
+    failures += check(!parse_openai_responses_create_request(null_body, limits())
+                          .prompt.generation.post_thinking.temperature,
+                      "post_thinking null treated as unset");
+
+    const Json range_body = {{"model", "m"},
+                             {"input", "hello"},
+                             {"post_thinking", Json{{"temperature", 3.0}}}};
+    failures += check(
+        api_error([&] { (void)parse_openai_responses_create_request(range_body, limits()); })
+            .param == "post_thinking",
+        "out-of-range post_thinking temperature rejected");
+
+    const Json bad_body = {{"model", "m"}, {"input", "hello"}, {"post_thinking", "text"}};
+    failures += check(
+        api_error([&] { (void)parse_openai_responses_create_request(bad_body, limits()); })
+            .message.find("post_thinking") != std::string::npos,
+        "non-object post_thinking rejected");
+    return failures;
+}
+
 int test_budgets_and_nonsemantic_hints() {
     const Json base = {{"model", "m"}, {"input", "hello"}};
     int failures    = 0;
@@ -279,7 +321,7 @@ int test_typed_items_and_cache_markers() {
                           resolved.generation.messages[1].tool_call_id == "call_1",
                       "typed Items survive call-graph normalization");
     const ninfer::PromptInput translated = to_prompt_input(
-        resolved.generation, ResolvedPromptSemantics{}, [](const ContentPart& part) {
+        resolved.generation, ServeOptions{}, ResolvedPromptSemantics{}, [](const ContentPart& part) {
             ninfer::OwnedMedia media;
             media.kind  = part.kind == ContentKind::Image ? ninfer::MediaKind::Image
                                                           : ninfer::MediaKind::Video;
@@ -963,6 +1005,7 @@ int test_input_tokens_uses_shared_state_path() {
 int main() {
     int failures = 0;
     failures += test_basic_request_and_resolution();
+    failures += test_post_thinking_sampling();
     failures += test_budgets_and_nonsemantic_hints();
     failures += test_typed_items_and_cache_markers();
     failures += test_contiguous_assistant_items();

--- a/tests/test_openai_schema.cpp
+++ b/tests/test_openai_schema.cpp
@@ -57,7 +57,8 @@ ResolvedPromptSemantics semantics(const GenerationRequest& request) {
 }
 
 ninfer::PromptInput prompt(const GenerationRequest& request) {
-    return to_prompt_input(request, semantics(request), {});
+    ServeOptions server;
+    return to_prompt_input(request, server, semantics(request), {});
 }
 
 ninfer::RequestOptions options(const GenerationRequest& request) {
@@ -118,6 +119,68 @@ int test_request_envelope_and_sampling() {
     malformed["stream_options"] = true;
     failures += check(api_error([&] { (void)parse(malformed); }).param == "stream_options",
                       "malformed stream_options rejected");
+    return failures;
+}
+
+int test_post_thinking_sampling() {
+    int failures = 0;
+    Json body = base_request();
+    body["post_thinking"] = Json{{"temperature", 0.2},
+                                 {"top_p", 0.9},
+                                 {"top_k", 7},
+                                 {"min_p", 0.1},
+                                 {"presence_penalty", 0.5},
+                                 {"frequency_penalty", -0.25},
+                                 {"seed", 42}};
+    const OpenAIChatRequest request = parse(body);
+    failures += check(request.generation.post_thinking.temperature &&
+                          *request.generation.post_thinking.temperature == 0.2 &&
+                          request.generation.post_thinking.top_k &&
+                          *request.generation.post_thinking.top_k == 7 &&
+                          request.generation.post_thinking.min_p &&
+                          *request.generation.post_thinking.min_p == 0.1,
+                      "post_thinking object parsed");
+    const ninfer::RequestOptions translated = options(request.generation);
+    failures += check(translated.execution.post_thinking_sampling.temperature &&
+                          *translated.execution.post_thinking_sampling.temperature == 0.2F &&
+                          *translated.execution.post_thinking_sampling.top_p == 0.9F &&
+                          *translated.execution.post_thinking_sampling.top_k == 7 &&
+                          *translated.execution.post_thinking_sampling.min_p == 0.1F &&
+                          *translated.execution.post_thinking_sampling.presence_penalty ==
+                              0.5F &&
+                          *translated.execution.post_thinking_sampling.frequency_penalty ==
+                              -0.25F &&
+                          *translated.execution.post_thinking_sampling.seed == 42,
+                      "post_thinking reaches Engine request options");
+
+    Json null_body = base_request();
+    null_body["post_thinking"] = nullptr;
+    const OpenAIChatRequest null_request = parse(null_body);
+    failures += check(!null_request.generation.post_thinking.temperature,
+                      "post_thinking null treated as unset");
+
+    Json bad = base_request();
+    bad["post_thinking"] = "text";
+    failures += check(api_error([&] { (void)parse(bad); }).param == "post_thinking",
+                      "non-object post_thinking rejected");
+
+    Json range = base_request();
+    range["post_thinking"] = Json{{"temperature", 3.0}};
+    const OpenAIChatRequest range_request = parse(range);
+    failures += check(
+        api_error([&] { (void)options(range_request.generation); }).param == "post_thinking",
+        "out-of-range post_thinking temperature rejected");
+
+    Json seed_body            = base_request();
+    seed_body["seed"]         = 99;
+    seed_body["post_thinking"] = Json{{"temperature", 0.2}};
+    const OpenAIChatRequest seed_request = parse(seed_body);
+    const ninfer::RequestOptions seed_options = options(seed_request.generation);
+    failures += check(seed_options.execution.sampling.seed &&
+                          *seed_options.execution.sampling.seed == 99 &&
+                          seed_options.execution.post_thinking_sampling.seed &&
+                          *seed_options.execution.post_thinking_sampling.seed == 99,
+                      "omitted post_thinking seed did not inherit the request seed");
     return failures;
 }
 
@@ -686,6 +749,7 @@ int test_common_objects() {
 int main() {
     int failures = 0;
     failures += test_request_envelope_and_sampling();
+    failures += test_post_thinking_sampling();
     failures += test_standard_field_policy();
     failures += test_constrained_decoding_extensions();
     failures += test_tools();

--- a/tests/test_sampling_defaults.cpp
+++ b/tests/test_sampling_defaults.cpp
@@ -74,6 +74,24 @@ int main() {
     failures += check(same_preset(qwen3_8.thinking, dense_thinking) &&
                           same_preset(qwen3_8.non_thinking, dense_non_thinking),
                       "Qwen3.8-27B defaults mismatch");
+    const ninfer::SamplingPreset dense_post_thinking{
+        .temperature = 0.2F, .top_k = 20, .top_p = 0.95F, .min_p = 0.0F};
+    const ninfer::SamplingPreset moe_post_thinking{
+        .temperature      = 0.2F,
+        .top_k            = 20,
+        .top_p            = 0.95F,
+        .min_p            = 0.0F,
+        .presence_penalty = 1.5F,
+    };
+    failures += check(same_preset(qwen3_6.post_thinking, dense_post_thinking) &&
+                          qwen3_6.has_post_thinking,
+                      "Qwen3.6-27B post-thinking defaults mismatch");
+    failures += check(same_preset(qwen3_8.post_thinking, dense_post_thinking) &&
+                          qwen3_8.has_post_thinking,
+                      "Qwen3.8-27B post-thinking defaults mismatch");
+    failures += check(same_preset(qwen3_6_35.post_thinking, moe_post_thinking) &&
+                          qwen3_6_35.has_post_thinking,
+                      "Qwen3.6-35B-A3B post-thinking defaults mismatch");
     failures += check(same_preset(qwen3_6_35.thinking, moe_thinking) &&
                           same_preset(qwen3_6_35.non_thinking, dense_non_thinking),
                       "Qwen3.6-35B-A3B defaults mismatch");
@@ -81,15 +99,36 @@ int main() {
                       "unknown model received dense-27B sampling defaults");
 
     const ninfer::ResolvedSamplingParameters thinking = ninfer::runtime::resolve_sampling(
-        qwen3_8, ninfer::SamplingMode::Thinking, ninfer::SamplingOverrides{});
+        qwen3_8, ninfer::SamplingPhase::Thinking, ninfer::SamplingOverrides{});
     const ninfer::ResolvedSamplingParameters non_thinking = ninfer::runtime::resolve_sampling(
-        qwen3_8, ninfer::SamplingMode::NonThinking, ninfer::SamplingOverrides{});
+        qwen3_8, ninfer::SamplingPhase::NonThinking, ninfer::SamplingOverrides{});
     failures += check(thinking.temperature == 1.0F && thinking.top_p == 0.95F &&
                           thinking.presence_penalty == 0.0F && thinking.seed == 0,
                       "omitted overrides did not select Qwen3.8 thinking defaults");
     failures += check(non_thinking.temperature == 0.7F && non_thinking.top_p == 0.8F &&
                           non_thinking.presence_penalty == 1.5F,
                       "omitted overrides did not select Qwen3.8 non-thinking defaults");
+
+    const ninfer::ResolvedSamplingParameters post_thinking = ninfer::runtime::resolve_sampling(
+        qwen3_8, ninfer::SamplingPhase::PostThinking, ninfer::SamplingOverrides{});
+    failures += check(post_thinking.temperature == 0.2F && post_thinking.top_p == 0.95F &&
+                          post_thinking.presence_penalty == 0.0F && post_thinking.seed == 0,
+                      "omitted overrides did not select Qwen3.8 post-thinking defaults");
+    failures += check(
+        ninfer::initial_sampling_phase(ninfer::SamplingMode::Thinking) ==
+                ninfer::SamplingPhase::Thinking &&
+            ninfer::initial_sampling_phase(ninfer::SamplingMode::NonThinking) ==
+                ninfer::SamplingPhase::NonThinking,
+        "initial sampling phase did not follow the thinking mode");
+    const ninfer::SamplingOverrides post_overrides{.temperature = 0.5F};
+    const ninfer::ResolvedSamplingParameters post_overridden =
+        ninfer::runtime::resolve_sampling(qwen3_8, ninfer::SamplingPhase::PostThinking,
+                                         post_overrides);
+    failures += check(post_overridden.temperature == 0.5F && post_overridden.top_p == 0.95F,
+                      "post-thinking override did not mix with the phase preset");
+    const ninfer::ModelSamplingDefaults unregistered{};
+    failures += check(!unregistered.has_post_thinking,
+                      "unregistered model advertised a post-thinking preset");
 
     ninfer::SamplingOverrides overrides;
     overrides.temperature       = 0.0F;
@@ -100,7 +139,7 @@ int main() {
     overrides.frequency_penalty = -1.0F;
     overrides.seed              = 123;
     const ninfer::ResolvedSamplingParameters overridden =
-        ninfer::runtime::resolve_sampling(qwen3_8, ninfer::SamplingMode::NonThinking, overrides);
+        ninfer::runtime::resolve_sampling(qwen3_8, ninfer::SamplingPhase::NonThinking, overrides);
     failures += check(overridden.temperature == 0.0F && overridden.top_k == 20 &&
                           overridden.top_p == 0.0F && overridden.presence_penalty == 0.0F &&
                           overridden.frequency_penalty == -1.0F && overridden.seed == 123,
@@ -109,7 +148,7 @@ int main() {
     overrides.top_k = 21;
     failures += check(throws_invalid([&] {
                           (void)ninfer::runtime::resolve_sampling(
-                              qwen3_8, ninfer::SamplingMode::Thinking, overrides);
+                              qwen3_8, ninfer::SamplingPhase::Thinking, overrides);
                       }),
                       "top_k beyond the executable candidate domain was accepted");
     overrides.top_k = 0;
@@ -117,7 +156,7 @@ int main() {
     overrides.temperature = std::numeric_limits<float>::quiet_NaN();
     failures += check(throws_invalid([&] {
                           (void)ninfer::runtime::resolve_sampling(
-                              qwen3_8, ninfer::SamplingMode::Thinking, overrides);
+                              qwen3_8, ninfer::SamplingPhase::Thinking, overrides);
                       }),
                       "non-finite sampling override was accepted");
 

--- a/tools/e2e/ninfer-e2e.py
+++ b/tools/e2e/ninfer-e2e.py
@@ -421,8 +421,8 @@ def parse_serve_log(path, skip_lines=0):
         "private_turn_closure", "tool_calls_done",
         "materialize_fallback", "materialize_safety_hit",
         "materialize_oom_first",
-        "checkpoint_demoted", "checkpoint_restored", "checkpoint_spill_merged",
-        "state_only_lru_evict", "finish_demote_fallback",
+        "checkpoint_demoted", "checkpoint_restored", "unit_not_retained",
+        "unit_partial_rejected", "unit_evicted_smallest_first",
         "hostonly_restore_fail",
         "kv_copy_skip",
         "host_copy_ok",
@@ -481,27 +481,27 @@ def parse_serve_log(path, skip_lines=0):
                     d["materialize_safety_hit"] += 1
                 if "[materialize] OOM (first)" in line:
                     d["materialize_oom_first"] += 1
-                if "[checkpoint-demoted]" in line:
-                    d["checkpoint_demoted"] += 1
                 if "[checkpoint] demoting old checkpoint to host" in line:
                     d["checkpoint_demoted"] += 1
                 # [rewrite-restore] restored demoted checkpoint from safety net
                 # -- pattern reserved for future Step 5-6 work (not emitted yet)
                 if "[rewrite-restore] restoring HostOnly checkpoint to device" in line:
                     d["checkpoint_restored"] += 1
-                if "[safety-spill] merged dropped checkpoint state" in line:
-                    d["checkpoint_spill_merged"] += 1
-                if "[safety-net] evicting oldest state-only entry" in line:
-                    d["state_only_lru_evict"] += 1
-                if "[checkpoint-demoted] finish-fallback" in line:
-                    d["finish_demote_fallback"] += 1
+                # A cache unit is {KV + state}. Non-retention is explicit, and a partial
+                # unit must never be stored; eviction reclaims whole units smallest-first.
+                if "[checkpoint] unit-not-retained" in line:
+                    d["unit_not_retained"] += 1
+                if "[safety-net] REJECT-PARTIAL" in line:
+                    d["unit_partial_rejected"] += 1
+                if "[host-state-pool] evict=" in line:
+                    d["unit_evicted_smallest_first"] += 1
                 if "[kv-not-resident]" in line and "STALE_HANDLE" in line:
                     d["kv_not_resident_stale"] += 1
                 if "[kv-not-resident]" in line and "VALID_BUT_NO_DEVICE" in line:
                     d["kv_not_resident_no_device"] += 1
                 if "[safety-spill] mixed_copy_ok" in line:
                     d["mixed_copy_ok"] += 1
-                if "insufficient capacity" in line and "state-only" in line:
+                if "[safety-spill] FAIL: insufficient capacity" in line:
                     d["spill_fail_capacity"] += 1
                 if "[safety-spill] host_copy_ok" in line:
                     d["host_copy_ok"] += 1
@@ -537,13 +537,13 @@ def evaluate(phase_name, sessions, stats0, stats1, log, expect_trash=False):
     if log.get("mixed_copy_ok", 0) > 0:
         v.append(f"PASS: {log['mixed_copy_ok']} mixed device+host copies (partial D2H worked)")
     if log.get("spill_fail", 0) > 0 and phase_name not in ("trash", "mixed", "concurrent"):
-        v.append(f"WARN: {log['spill_fail']} spill failures (check state-only fallback)")
+        v.append(f"WARN: {log['spill_fail']} spill failures (a unit could not be completed)")
     if log.get("spill_fail_capacity", 0) > 0:
-        v.append(f"WARN: {log['spill_fail_capacity']} spill capacity failures (fell back to state-only)")
+        v.append(f"WARN: {log['spill_fail_capacity']} spill capacity failures (no room for a complete unit)")
     if log.get("host_copy_ok", 0) > 0:
         v.append(f"PASS: {log['host_copy_ok']} host replica copies (demoted KV recovered from host)")
     if log.get("kv_copy_skip", 0) > 0:
-        v.append(f"WARN: {log['kv_copy_skip']} KV copy skips (device pages unavailable, state-only fallback)")
+        v.append(f"WARN: {log['kv_copy_skip']} KV copy skips (device pages unavailable, unit not retained)")
     if log["bad_alloc"] > 0 and phase_name in ("trash", "mixed", "concurrent", "tool-calling"):
         v.append(f"PASS: {log['bad_alloc']} std::bad_alloc caught and recovered (extreme pressure handled)")
 
@@ -791,19 +791,26 @@ def evaluate(phase_name, sessions, stats0, stats1, log, expect_trash=False):
     # of dropping rewrite checkpoints. Checkpoint state is preserved via
     # the safety net spill (ckpt_ok) or demotion capture.
     if phase_name == "demotion":
-        preserved = log["checkpoint_demoted"] + log["spill_ckpt_ok"]
-        if preserved > 0:
-            v.append(f"PASS: {preserved} checkpoint states preserved "
-                     f"(demoted={log['checkpoint_demoted']}, spill_ckpt={log['spill_ckpt_ok']})")
+        # A cache unit is {attention KV + GDN state} and is retained whole or not at
+        # all. Checkpoint state therefore survives only inside a retained unit, and
+        # an explicit non-retention is the correct outcome when the shared host
+        # budget cannot hold the whole unit - it is not a failure.
+        # spill_ckpt_ok is counted inside the spill_ok branch, so it is a subset; use
+        # spill_ok alone as the unit count and report the checkpoint-bearing share.
+        retained = log["spill_ok"]
+        if retained > 0:
+            v.append(f"PASS: {retained} complete units retained "
+                     f"(spill_ok={log['spill_ok']}, spill_ckpt={log['spill_ckpt_ok']})")
         else:
-            v.append("FAIL: no checkpoint state preserved in demotion phase")
+            v.append("FAIL: no complete {KV + state} unit retained in demotion phase")
         if log["checkpoint_restored"] > 0:
             v.append(f"PASS: {log['checkpoint_restored']} checkpoint restores from safety net")
-        if log["checkpoint_spill_merged"] > 0:
-            v.append(f"PASS: {log['checkpoint_spill_merged']} spill merges consolidated state")
-        if log["checkpoint_demoted"] > 0 and log["checkpoint_restored"] == 0:
-            v.append(f"PASS: {log['checkpoint_demoted']} checkpoint demotions (restored 0 — "
-                     "sessions did not return before phase ended, state preserved in safety net)")
+        if log["unit_partial_rejected"] > 0:
+            v.append(f"FAIL: {log['unit_partial_rejected']} partial units were offered for retention")
+        if log["unit_not_retained"] > 0:
+            v.append(f"INFO: {log['unit_not_retained']} captures not retained (no complete unit)")
+        if log["unit_evicted_smallest_first"] > 0:
+            v.append(f"INFO: {log['unit_evicted_smallest_first']} units reclaimed smallest-first")
         if log["rewrite_restore_fail"] > 0:
             v.append(f"FAIL: {log['rewrite_restore_fail']} rewrite restore failures")
 


### PR DESCRIPTION
One change that lands a sampler feature, an engine-memory fix, and the measurements that qualify
both. Squashed from the development history so the whole thing can be reviewed and merged as a unit;
the three parts are independent and described separately below.

================================================================================
PART 1 - Post-thinking sampling: switch sampler at the reasoning close
================================================================================

A thinking request resolves one sampling preset at submission and uses it for the entire
generation, so the reasoning block and the final answer share a temperature. This adds a second
preset that takes effect from the token after the model closes its reasoning block.

- `SamplingPhase` (`Thinking`, `PostThinking`, `NonThinking`) and
  `ModelSamplingDefaults::post_thinking` with `has_post_thinking`. Registered values:
  thinking 1.0/0.95/20, post-thinking 0.2/0.95/20, non-thinking 0.7/0.80/20.
- The engine resolves both phases at submit and switches the device sampler once when the output
  session reports reasoning closed. The switch needs `SamplingMode::Thinking` and a registered
  post-thinking preset; otherwise behaviour is unchanged.
- CLI: `--post-thinking-temperature/-top-p/-top-k`, or the combined
  `--post-thinking-sampler temp=..,top_p=..,top_k=..`. `--greedy` pins both phases to argmax.
- HTTP: an optional `post_thinking` object on OpenAI Chat Completions, OpenAI Responses and
  Anthropic Messages; omitted fields fall back to the registered preset, and an omitted seed
  inherits the request's resolved seed.

================================================================================
PART 2 - Engine fix: retain the context cache as one atomic {KV + state} unit
================================================================================

Why. The host-KV safety net stored "state-only" entries: a state image with no KV allocations, with
the KV left on device. State images are ordinary heap, invisible to `host_kv_occupied_bytes`, which
reports the arena's occupied bytes - so the arena sat at or below its cap while process RSS climbed
without limit: measured at 23 GiB and rising after 30 distinct conversations against a 4 GiB host
budget, and about 53 GiB in the production shape before the OOM killer fired. Five paths produced
such entries, including the spill function's own fallback ("Pages missing - can't recover. Fall back
to state-only"). Because the growth looked like arena pressure it was misdiagnosed as a pinned-arena
capacity problem.

Why halves are not independently useful. The KV covers only the attention layers; the state image
carries the GDN recurrent state. Resuming needs both. KV without state cannot resume and is not
cheaper than losing both, because the attention K/V at a position depends on the hidden state
produced by the preceding GDN layers, so it is not independently recomputable - any recompute is a
full prefix pass, which rebuilds the GDN state and regenerates the KV being kept. State without KV
is only usable while that KV is device-resident. A partially-retained unit is therefore a bug and a
correctness hazard, since prefix matching can select it and restore with a missing half.

- `HostKVSafetyNet::add()` refuses any entry that is not a complete unit (retained KV pages AND a
  state image).
- The spill function aborts and retains nothing instead of falling back to state-only retention.
- The state-only class is removed entirely: the `state_only` and `source_continuation_index` fields,
  the five `take_state_only*`/`remove_state_only*` methods, their callers, and the state-only skip
  branches in the arena eviction scans.
- The five capture sites no longer build state-only entries. They log `[checkpoint] unit-not-retained`
  so non-retention is explicit, and they no longer perform the ~150 MB D2H copy whose result nothing
  retained - which previously ran on every clean-append turn and every root prefill.
- Victim selection is cost-aware, NOT strict LRU: complete units only, smallest retained KV page
  count first, recency breaking ties, matching the existing evict-smallest semantics.
- Retention is bounded by one shared host budget covering the unit's full size, with the arena queried
  live so neither tenant consumes the other's headroom; `occupied <= capacity` holds in `/stats`.

Deliberate consequence: when the shared budget cannot hold a whole unit, the capture is refused
rather than degraded, so checkpoint-level restore is unavailable for units that do not fit. That is
the fail-closed trade the invariant requires, and it is visible in the logs.

Validation: on the RTX 5090 host the reproducer holds RSS flat at 10.03 GiB with host_kv at
3.90/4.00 GiB over 60 conversations against 23 GiB and rising before, and across 2480 spills in the
BFCL campaign no partial unit was ever offered for retention (REJECT-PARTIAL = 0) with ~3.2k complete
units retained and ~3.2k whole-unit evictions per arm.

================================================================================
PART 3 - Measurements that qualify the feature, and their honest result
================================================================================

The sampler's premise - that a lower answer-phase temperature reduces errors in answers and tool
calls - did not reproduce on this stack. Thinking frozen at 1.0, only `post_thinking` differing:
BFCL v4 tool calling is quality-neutral (1240 paired samples, 86.0% against 85.8%, exact McNemar
p = 0.79, error-type histograms matching category for category); AIME is flat within a +/-4 pp band
(90.00/90.00/86.67% for emissions 0.0/0.2/1.0); IFBench is identical at 0.2 and 1.0 (0.6367 both).
Malformed symbolic answers are 0% everywhere.

What the knob does measurably: it changes which tokens are emitted (90.3% of plans produce four
distinct emissions across a ladder) without changing any aggregate, and it improves reproducibility
of long free-form answers under numerical-route variation (100% to 62.5% distinct answers at
identical route variation, similarity 0.389 to 0.629). It is therefore a reliability setting rather
than a quality one, and the registered 0.2 should be reviewed - the study recommends mirroring the
thinking sampler with 0.2 as an explicit opt-in. That change is NOT made here; 0.2 remains the
registered value.

ReSET-style entropy-gated temperature is deferred for this setup: the symbolic damage pool it targets
is unobservable here, this artifact is already quantization-aware trained, and the controlled
QUASAR-versus-Ostfralla comparison shows no significant artifact-quality gap (91.7% against 86.7%,
under one standard error at n=60).

A separate finding is recorded because it constrains evaluation practice: the engine is not
batch-invariant. Identical (prompt, seed, params) reproduces sequentially but not with two requests
in flight (three distinct reasoning blocks from eight identical requests), and cold-prefill versus
cache-warm routes differ. Paired "identical prefix" evaluation designs are therefore unsound unless
the route is held constant, and a fixed seed does not make a cached response reproducible.

================================================================================
ALSO IN THIS CHANGE
================================================================================

- serve: accept signed-integer `post_thinking` seeds in the Responses adapter (nlohmann reports a
  C++ int as number_integer, not number_unsigned).
- tests: pass ServeOptions to to_prompt_input in the serve schema tests.
- tests: the family frontend test resolves the official Qwen3.6-27B tokenizer from
  NINFER_QWEN3_6_27B_BASE with the legacy path as fallback and skips with 77 when absent, instead of
  requiring a maintainer-only checkout path.
- tests: an end-to-end host-memory regression test that asserts bounded RSS growth, the shared-budget
  invariant, atomicity, and that retention still works.
- docs: README, docs/cli.md and docs/serving.md document the new parameters and their measured
  effect; docs/performance.md records the BFCL campaign; docs/maintainer/post-thinking-temperature.md
  records the full study with cited literature; plan.md gains a status and measured-outcome block for
  the post-thinking design.

Validation: WSL build rc=0 on this tree, the five targeted unit tests pass, and the host-memory e2e
test passes against the real artifact.
